### PR TITLE
feat: add separate Code Mode for fenced code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+-   **Code Mode with separate code-block embeddings** (#52): Fenced code blocks can now move into an independent Code index with their own embedding-provider and model configuration. Similar-note views and Semantic Search gain an explicit Notes/Code selector, code-only previews, independent indexing/error state, and separate IndexedDB storage. Code Mode remains off by default; disabling it restores the previous whole-note indexing behavior.
+
 ## [1.6.0] - 2026-07-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Press `Cmd+Shift+O` (or `Ctrl+Shift+O`) to search your vault by meaning, not jus
 - **Mobile & Desktop**: Built-in models work on iOS, Android, and all desktop platforms
 - **OpenAI Support**: Use OpenAI embedding models or any OpenAI-compatible API
 - **Ollama Support**: Connect to custom models via Ollama (desktop only)
+- **Code Mode**: Index fenced code blocks separately with an independent embedding model
 - **No Setup Required**: Built-in models work out of the box, no API keys needed
 
 ## Getting Started
@@ -79,6 +80,21 @@ Supports any Ollama embedding model.
 - `nomic-embed-text` (English)
 - `bge-m3` (multilingual)
 
+### Code Mode
+
+Enable **Index fenced code blocks separately** under **Settings → Similar Notes → Code mode** to build an independent Code index. When enabled:
+
+- fenced code blocks move out of the normal Notes index;
+- the similar-notes views and Semantic Search gain a **Notes / Code** selector;
+- Code results show matches from fenced blocks only;
+- the Code index can use its own built-in, Ollama, OpenAI-compatible, or Gemini embedding model.
+
+Code Mode starts with a copy of the current Notes model configuration; change it under **Code model** if a code-specialized model or separate provider is preferred. Notes and Code scores remain separate because similarity values from different embedding models are not directly comparable.
+
+> **Resource note**: two indexes use more memory and local storage. Loading two different built-in models can exceed a phone's memory budget, so a remote Code model is recommended on mobile.
+
+> **Privacy note**: when the Code model uses a remote provider, fenced source code is sent to that provider under its data-handling policy.
+
 ## Agent Usage
 
 The active note's similar-notes results can be exported to a JSON file, so an external coding agent can reuse the plugin's similarity search without understanding embeddings or plugin internals:
@@ -115,6 +131,7 @@ For driving the command from an agent (CLI flow, validation tips, drop-in skill 
 - **Transformers.js**: Runs Hugging Face models directly in Obsidian
 - **WebGPU**: GPU acceleration on desktop, automatic CPU fallback
 - **Orama**: Built-in vector database for fast search
+- **Separate vector spaces**: Notes and Code use independent Orama/IndexedDB stores and may have different vector dimensions
 - **Web Workers**: All processing runs in background threads
 
 ## Multi-Device Usage

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,6 +45,7 @@ src/
 - **SettingsService** (`application/SettingsService.ts`): Handles plugin settings management and persistence.
 - **SimilarNoteCoordinator** (`application/SimilarNoteCoordinator.ts`): Coordinates similar note finding and UI updates.
 - **LeafViewCoordinator** (`application/LeafViewCoordinator.ts`): Manages Obsidian leaf views and bottom panel display.
+- **CodeModeRuntime** (`application/CodeModeRuntime.ts`): Owns the optional Code model, index, queue, finder, search service, and teardown lifecycle.
 
 ### Infrastructure
 - **VaultNoteRepository** (`infrastructure/VaultNoteRepository.ts`): Implementation of NoteRepository for Obsidian vault.
@@ -67,11 +68,13 @@ src/
 
 6. **Built-in embedding per-pass batch cap**: The built-in (Transformers.js / onnxruntime-web) embedder caps chunks per forward pass at `MAX_EMBED_BATCH_SIZE` (32) and runs sub-batches sequentially (`transformers.worker.ts`, `splitIntoBatches`/`embedInBatches` in `src/utils/batching.ts`). Embedding a large note's chunks in one pass overran the wasm32 ~4GB address space and aborted with a bare number (and then cascaded). Note: this is *not* a threading issue — the beta.4 single-thread pin was a no-op. See `docs/builtin-embedding-batch-cap-spec.md`.
 
-5. **Settings Storage**: Plugin settings are stored in Obsidian's data.json. UI for settings uses React components.
+7. **Code Mode uses a separate vector space**: When enabled, fenced blocks are removed from the Notes corpus and indexed by a second model/repository/queue pipeline. The Code IndexedDB namespace is `<vaultId>-similar-notes-code`; the existing Notes namespace remains unchanged. Search surfaces select one index explicitly and never blend raw scores across models. Extraction, invalidation, failure, memory, and privacy behavior are specified in `docs/code-mode-spec.md`.
+
+8. **Settings Storage**: Plugin settings are stored in Obsidian's data.json. UI for settings uses React components.
 
    - **Sectioning**: The settings tab is divided into top-level sections using Obsidian's `SettingGroup` (`@since 1.11.0`) — one per area (e.g. Model, Index, Exclude folders from index, Exclude content from index, Display, Debug & Support). Each section is built by a `*SettingsSection` class (e.g. `IndexSettingsSection`) that returns `SettingBuilder` arrays.
    - **Use sibling groups, not sub-headings.** `SettingGroup` cannot nest, and inserting `Setting.setHeading()` divider rows *inside* a group renders poorly (tried more than once and reverted). To break a crowded section into sub-areas, add another sibling top-level `SettingGroup` instead of nesting or in-group headings.
 
-5. **Content Exclusion**: Supports RegExp patterns to exclude content from indexing (e.g., frontmatter, code blocks).
+9. **Content Exclusion**: Supports RegExp patterns to exclude content from indexing (e.g., frontmatter, code blocks).
 
-6. **Command Palette**: Commands are implemented in `src/commands/` with a extensible structure for easy addition of new commands.
+10. **Command Palette**: Commands are implemented in `src/commands/` with a extensible structure for easy addition of new commands.

--- a/docs/code-mode-spec.md
+++ b/docs/code-mode-spec.md
@@ -1,0 +1,105 @@
+# Code Mode Specification
+
+## Status
+
+Accepted for issue #52.
+
+## User workflow
+
+Code Mode is opt-in. When disabled, Similar Notes keeps its existing behavior and
+indexes the complete Markdown body, including fenced code blocks.
+
+When enabled, Similar Notes partitions each indexable note into two independent
+corpora:
+
+- **Notes** contains prose with fenced code blocks removed.
+- **Code** contains fenced code blocks and their language metadata.
+
+Semantic Search and the similar-notes views expose an explicit Notes/Code mode.
+Results from the two modes are not mixed because independent embedding models do
+not produce calibrated, directly comparable similarity scores.
+
+## Markdown partitioning
+
+Partitioning runs after frontmatter handling and configured regular-expression
+exclusions. The extractor recognizes CommonMark-style backtick and tilde fences,
+including variable fence lengths, up to three leading spaces, info strings,
+empty blocks, and an unterminated final block.
+
+Inline code spans are not code blocks. Removing a fenced block from prose keeps
+surrounding line boundaries stable so unrelated paragraphs are not joined.
+
+Each code block retains:
+
+- language from the first info-string token, if present;
+- zero-based block position within the note;
+- source content without opening and closing fences.
+
+Code chunks preserve line boundaries. The embedding input includes the note
+title and language context, while stored previews contain the original code.
+
+## Model ownership
+
+The Notes and Code profiles can use different providers and models. A Code
+profile is initially copied from the active Notes profile; no code model is
+silently selected for the user.
+
+If both profiles resolve to the same effective configuration, they share the
+loaded embedding service. Distinct configurations use isolated services so one
+profile cannot dispose or switch the other profile while indexing is active.
+Code resources load only while Code Mode is enabled.
+
+## Persistence
+
+The existing Notes index keeps its current IndexedDB name:
+`<vaultId>-similar-notes`.
+
+The Code index uses `<vaultId>-similar-notes-code`. Separate databases are
+required because an Orama vector field has one fixed dimension and the two
+models may return different dimensions.
+
+Index progress and terminal errors are also namespaced. A successful Notes
+write does not mark the Code target current, and a Code failure does not suppress
+future Notes processing.
+
+## Invalidation
+
+| Setting change | Required work |
+| --- | --- |
+| Enable Code Mode | Rebuild Notes and build Code |
+| Disable Code Mode | Rebuild Notes and remove Code runtime data |
+| Code provider, model, URL, or maximum tokens | Rebuild Code only |
+| Code API key or GPU execution mode | Reload Code provider only |
+| Notes model | Rebuild Notes only |
+| Folder or content exclusions | Reconcile both enabled indexes |
+
+File creation, modification, deletion, and rename are processed independently by
+the two index queues. Rename reuses stored vectors when the indexed mtime still
+matches. A target's mtime advances only after its repository operation succeeds.
+
+## Query behavior
+
+Notes mode uses the existing note chunks and model. Code mode extracts code from
+the source note, queries only the Code index, excludes the source file, keeps the
+best matching chunk per destination note, and shows code previews. A source note
+without fenced code returns an empty Code result with a mode-specific message.
+
+Coordinator caches include file mtime, search mode, and the relevant model
+profile. Changing mode or profile cannot reuse results from another index.
+
+## Resource and privacy constraints
+
+Two enabled indexes increase IndexedDB and Orama memory usage. Two distinct
+built-in models can exceed a mobile device's memory budget, so the UI warns
+before that configuration and recommends a remote provider on mobile.
+
+Code sent to a remote Code provider follows that provider's privacy policy. API
+keys remain excluded from environment diagnostics.
+
+## Verification
+
+Automated coverage must include extraction edge cases, independent persistence
+namespaces and dimensions, dual queue invalidation, settings migration, model
+isolation, mode-specific querying, cache invalidation, and disabled-mode
+compatibility. Manual verification uses `npm run install-local` and the
+`Test_local` vault described in `CLAUDE.md`.

--- a/src/adapter/orama/OramaDatabase.ts
+++ b/src/adapter/orama/OramaDatabase.ts
@@ -42,7 +42,8 @@ export class OramaWorker {
     async init(
         vectorSize: number,
         vaultId: string,
-        loadExistingData: boolean
+        loadExistingData: boolean,
+        namespace?: string
     ): Promise<void> {
         this.vectorSize = vectorSize;
         this.db = null;
@@ -60,7 +61,7 @@ export class OramaWorker {
         try {
             // Initialize IndexedDB storage with vault-specific ID
             this.storage = new IndexedDBChunkStorage();
-            await this.storage.init(vaultId);
+            await this.storage.init(vaultId, namespace);
 
             if (!loadExistingData) {
                 // Reindex scenario: clear IndexedDB to start fresh

--- a/src/adapter/orama/OramaNoteChunkRepository.ts
+++ b/src/adapter/orama/OramaNoteChunkRepository.ts
@@ -10,7 +10,10 @@ import InlineWorker from "./orama.worker";
 export class OramaNoteChunkRepository implements NoteChunkRepository {
     private workerManager: WorkerManager<OramaWorker>;
 
-    constructor(private readonly vault: Vault) {
+    constructor(
+        private readonly vault: Vault,
+        private readonly namespace?: string
+    ) {
         this.workerManager = new WorkerManager<OramaWorker>("OramaWorker");
     }
 
@@ -24,7 +27,8 @@ export class OramaNoteChunkRepository implements NoteChunkRepository {
         await worker.init(
             vectorSize,
             vaultId,
-            loadExistingData
+            loadExistingData,
+            this.namespace
         );
     }
 

--- a/src/adapter/orama/__tests__/OramaDatabase.test.ts
+++ b/src/adapter/orama/__tests__/OramaDatabase.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const storageMocks = vi.hoisted(() => ({
+    init: vi.fn(),
+    clear: vi.fn(),
+    loadInBatches: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/infrastructure/IndexedDBChunkStorage", () => ({
+    IndexedDBChunkStorage: class {
+        init = storageMocks.init;
+        clear = storageMocks.clear;
+        loadInBatches = storageMocks.loadInBatches;
+    },
+}));
+
+import { OramaWorker } from "../OramaDatabase";
+
+describe("OramaWorker namespaces", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("preserves the default storage namespace", async () => {
+        const worker = new OramaWorker();
+
+        await worker.init(384, "test-vault", true);
+
+        expect(storageMocks.init).toHaveBeenCalledWith(
+            "test-vault",
+            undefined
+        );
+    });
+
+    it("forwards a code namespace to storage", async () => {
+        const worker = new OramaWorker();
+
+        await worker.init(768, "test-vault", true, "code");
+
+        expect(storageMocks.init).toHaveBeenCalledWith("test-vault", "code");
+    });
+});

--- a/src/adapter/orama/__tests__/OramaNoteChunkRepository.test.ts
+++ b/src/adapter/orama/__tests__/OramaNoteChunkRepository.test.ts
@@ -1,0 +1,55 @@
+import type { Vault } from "obsidian";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const workerMocks = vi.hoisted(() => {
+    const init = vi.fn();
+
+    return {
+        init,
+        initialize: vi.fn(async () => ({ init })),
+    };
+});
+
+vi.mock("@/infrastructure/WorkerManager", () => ({
+    WorkerManager: class {
+        initialize = workerMocks.initialize;
+    },
+}));
+
+vi.mock("../orama.worker", () => ({
+    default: class {},
+}));
+
+import { OramaNoteChunkRepository } from "../OramaNoteChunkRepository";
+
+describe("OramaNoteChunkRepository namespaces", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("preserves the default worker initialization API", async () => {
+        const repository = new OramaNoteChunkRepository({} as Vault);
+
+        await repository.init(384, "test-vault", true);
+
+        expect(workerMocks.init).toHaveBeenCalledWith(
+            384,
+            "test-vault",
+            true,
+            undefined
+        );
+    });
+
+    it("forwards a code namespace to the worker", async () => {
+        const repository = new OramaNoteChunkRepository({} as Vault, "code");
+
+        await repository.init(768, "test-vault", false);
+
+        expect(workerMocks.init).toHaveBeenCalledWith(
+            768,
+            "test-vault",
+            false,
+            "code"
+        );
+    });
+});

--- a/src/application/CodeModeRuntime.ts
+++ b/src/application/CodeModeRuntime.ts
@@ -1,0 +1,441 @@
+import { OramaNoteChunkRepository } from "@/adapter/orama/OramaNoteChunkRepository";
+import {
+    CURRENT_CODE_INDEX_VERSION,
+    snapshotNoteModelSettings,
+    type EmbeddingModelSettings,
+    type SettingsService,
+} from "@/application/SettingsService";
+import type { NoteRepository } from "@/domain/repository/NoteRepository";
+import { EmbeddingService } from "@/domain/service/EmbeddingService";
+import {
+    embeddingProfilesEqual,
+    getEmbeddingIndexFingerprint,
+} from "@/domain/service/embeddingProfile";
+import { SimilarNoteFinder } from "@/domain/service/SimilarNoteFinder";
+import {
+    type TextSearch,
+    TextSearchService,
+} from "@/domain/service/TextSearchService";
+import { ErroredNoteStore } from "@/infrastructure/ErroredNoteStore";
+import { FencedCodeBlockExtractor } from "@/infrastructure/FencedCodeBlockExtractor";
+import { FencedCodeNoteChunkingService } from "@/infrastructure/FencedCodeNoteChunkingService";
+import { IndexedNoteMTimeStore } from "@/infrastructure/IndexedNoteMTimeStore";
+import { LinePreservingCodeChunkingService } from "@/infrastructure/LinePreservingCodeChunkingService";
+import { NoteChangeQueue } from "@/services/noteChangeQueue";
+import log from "loglevel";
+import { Notice, Platform, type App } from "obsidian";
+import { NoteIndexingService } from "./NoteIndexingService";
+import type { SimilarNoteCoordinator } from "./SimilarNoteCoordinator";
+
+interface CodeModeRuntimeOptions {
+    app: App;
+    settingsService: SettingsService;
+    noteRepository: NoteRepository;
+    notesModelService: EmbeddingService;
+    similarNoteCoordinator: SimilarNoteCoordinator;
+    extractor: FencedCodeBlockExtractor;
+    rebuildNotesForModeToggle: () => Promise<void>;
+}
+
+export interface CodeModeStatus {
+    indexedNotes: number;
+    chunks: number;
+    erroredNotes: number;
+}
+
+/** Owns every optional Code index resource and its independent lifecycle. */
+export class CodeModeRuntime {
+    private chunkRepository?: OramaNoteChunkRepository;
+    private changeQueue?: NoteChangeQueue;
+    private modelService?: EmbeddingService;
+    private similarNoteFinder?: SimilarNoteFinder;
+    private textSearchService?: TextSearchService;
+    private readonly coordinatedTextSearchService: TextSearch;
+    private indexingService?: NoteIndexingService;
+    private indexedNotesMTimeStore?: IndexedNoteMTimeStore;
+    private erroredNoteStore?: ErroredNoteStore;
+    private sharesNotesModelService = false;
+
+    constructor(private readonly options: CodeModeRuntimeOptions) {
+        this.coordinatedTextSearchService = {
+            checkTokenLimit: (text) =>
+                this.runTextSearch((service) =>
+                    service.checkTokenLimit(text)
+                ),
+            findSimilarNotesFromText: (text, limit) =>
+                this.runTextSearch((service) =>
+                    service.findSimilarNotesFromText(text, limit)
+                ),
+        };
+    }
+
+    getSearchService(): TextSearch | undefined {
+        return this.textSearchService ? this.coordinatedTextSearchService : undefined;
+    }
+
+    private async runTextSearch<T>(
+        operation: (service: TextSearchService) => Promise<T>
+    ): Promise<T> {
+        return await this.options.similarNoteCoordinator.runSearchOperation(
+            "code",
+            async () => {
+                if (!this.textSearchService) {
+                    throw new Error("Code index is not ready");
+                }
+                return await operation(this.textSearchService);
+            }
+        );
+    }
+
+    async getStatus(): Promise<CodeModeStatus> {
+        let chunks = 0;
+        if (this.chunkRepository) {
+            try {
+                chunks = await this.chunkRepository.count();
+            } catch {
+                // Runtime may still be loading; surface zero until it is ready.
+            }
+        }
+        return {
+            indexedNotes: this.indexedNotesMTimeStore?.getCurrentIndexedNoteCount() ?? 0,
+            chunks,
+            erroredNotes: this.erroredNoteStore?.getCurrentErroredCount() ?? 0,
+        };
+    }
+
+    async applyChanges(
+        enabled: boolean,
+        codeModel: EmbeddingModelSettings
+    ): Promise<void> {
+        const apply = async () =>
+            this.options.similarNoteCoordinator.runSearchTransition(
+                "code",
+                async () => this.applyChangesUnlocked(enabled, codeModel)
+            );
+        if (
+            this.options.settingsService.get().codeModeEnabled !== enabled
+        ) {
+            await this.options.similarNoteCoordinator.runSearchTransition(
+                "notes",
+                apply
+            );
+        } else {
+            await apply();
+        }
+    }
+
+    private async applyChangesUnlocked(
+        enabled: boolean,
+        codeModel: EmbeddingModelSettings
+    ): Promise<void> {
+        const previous = this.options.settingsService.get();
+        const previousSettings = {
+            ...previous,
+            codeModel: previous.codeModel
+                ? { ...previous.codeModel }
+                : undefined,
+        };
+        const previousCodeModel = previous.codeModel
+            ? { ...previous.codeModel }
+            : snapshotNoteModelSettings(previous);
+        const modeChanged = previous.codeModeEnabled !== enabled;
+        const indexChanged =
+            getEmbeddingIndexFingerprint(previousCodeModel) !==
+            getEmbeddingIndexFingerprint(codeModel);
+
+        try {
+            await this.options.settingsService.update({
+                codeModeEnabled: enabled,
+                codeModel: { ...codeModel },
+                similarityMode: enabled ? previous.similarityMode : "notes",
+            });
+
+            if (enabled) {
+                await this.initializeUnlocked(!modeChanged && !indexChanged);
+            } else {
+                await this.teardown(true);
+            }
+            if (modeChanged) {
+                await this.options.rebuildNotesForModeToggle();
+            }
+        } catch (error) {
+            await this.options.settingsService.update(previousSettings);
+            try {
+                if (previousSettings.codeModeEnabled) {
+                    await this.initializeUnlocked(false);
+                } else {
+                    await this.teardown(true);
+                }
+                if (modeChanged) {
+                    await this.options.rebuildNotesForModeToggle();
+                }
+            } catch (rollbackError) {
+                log.error(
+                    "Failed to restore Code Mode after apply failure",
+                    rollbackError
+                );
+            }
+            throw error;
+        }
+    }
+
+    async initialize(loadExistingData: boolean): Promise<void> {
+        await this.options.similarNoteCoordinator.runSearchTransition(
+            "code",
+            async () => this.initializeUnlocked(loadExistingData)
+        );
+    }
+
+    private async initializeUnlocked(
+        loadExistingData: boolean,
+        forceNotesModel = false
+    ): Promise<void> {
+        await this.teardown(false);
+
+        const settings = this.options.settingsService.get();
+        let codeModel = settings.codeModel;
+        if (!codeModel) {
+            codeModel = snapshotNoteModelSettings(settings);
+            await this.options.settingsService.update({ codeModel });
+        }
+        const codeIndexFingerprint = [
+            CURRENT_CODE_INDEX_VERSION,
+            getEmbeddingIndexFingerprint(codeModel),
+        ].join(":");
+        const shouldLoadExistingData =
+            loadExistingData &&
+            settings.codeIndexFingerprint === codeIndexFingerprint;
+
+        this.sharesNotesModelService =
+            forceNotesModel || embeddingProfilesEqual(settings, codeModel);
+        if (this.sharesNotesModelService) {
+            this.modelService = this.options.notesModelService;
+        } else {
+            this.warnAboutTwoBuiltinModels(settings, codeModel);
+            this.modelService = new EmbeddingService(
+                this.options.settingsService,
+                async () => this.disableCodeGPU()
+            );
+            await this.modelService.switchProvider(codeModel);
+        }
+
+        const modelService = this.modelService;
+        if (!modelService) {
+            throw new Error("Code embedding model failed to initialize");
+        }
+
+        this.chunkRepository = new OramaNoteChunkRepository(
+            this.options.app.vault,
+            "code"
+        );
+        this.indexedNotesMTimeStore = new IndexedNoteMTimeStore("code");
+        this.erroredNoteStore = new ErroredNoteStore("code");
+
+        // @ts-expect-error - appId exists at runtime but not in type definitions
+        const vaultId = this.options.app.appId as string;
+        await Promise.all([
+            this.indexedNotesMTimeStore.init(vaultId),
+            this.erroredNoteStore.init(vaultId),
+        ]);
+        if (!shouldLoadExistingData) {
+            await Promise.all([
+                this.indexedNotesMTimeStore.clear(),
+                this.erroredNoteStore.clear(),
+            ]);
+        }
+
+        const chunkingService = new FencedCodeNoteChunkingService(
+            this.options.extractor,
+            new LinePreservingCodeChunkingService(modelService)
+        );
+        await chunkingService.init();
+        await this.chunkRepository.init(
+            modelService.getVectorSize(),
+            vaultId,
+            shouldLoadExistingData
+        );
+
+        this.similarNoteFinder = new SimilarNoteFinder(
+            this.chunkRepository,
+            chunkingService,
+            modelService
+        );
+        this.textSearchService = new TextSearchService(
+            this.chunkRepository,
+            modelService
+        );
+        this.options.similarNoteCoordinator.setCodeSimilarNoteFinder(
+            this.similarNoteFinder
+        );
+
+        this.changeQueue = new NoteChangeQueue(
+            this.options.app.vault,
+            this.indexedNotesMTimeStore,
+            this.options.settingsService,
+            this.erroredNoteStore
+        );
+        await this.changeQueue.initialize();
+        if (!shouldLoadExistingData) {
+            await this.changeQueue.enqueueAllNotes();
+        }
+
+        this.indexingService = new NoteIndexingService(
+            this.options.noteRepository,
+            this.chunkRepository,
+            this.changeQueue,
+            chunkingService,
+            modelService,
+            this.options.similarNoteCoordinator,
+            this.options.settingsService,
+            this.options.app,
+            this.erroredNoteStore,
+            "code"
+        );
+        this.indexingService.startLoop();
+        await this.options.settingsService.update({
+            codeIndexVersion: CURRENT_CODE_INDEX_VERSION,
+            codeIndexFingerprint,
+        });
+    }
+
+    async switchNotesModel(settings: EmbeddingModelSettings): Promise<void> {
+        await this.options.similarNoteCoordinator.runSearchTransition(
+            "code",
+            async () => {
+                if (!this.sharesNotesModelService) {
+                    await this.options.notesModelService.switchProvider(settings);
+                    return;
+                }
+
+                const current = this.options.settingsService.get();
+                const codeModel =
+                    current.codeModel ?? snapshotNoteModelSettings(current);
+                if (!embeddingProfilesEqual(current, codeModel)) {
+                    try {
+                        await this.initializeUnlocked(true);
+                    } catch (error) {
+                        try {
+                            await this.initializeUnlocked(true, true);
+                        } catch (restoreError) {
+                            log.error(
+                                "Failed to restore shared Code runtime",
+                                restoreError
+                            );
+                        }
+                        throw error;
+                    }
+                    await this.options.notesModelService.switchProvider(settings);
+                    return;
+                }
+
+                this.indexingService?.stopLoop();
+                await this.indexingService?.waitUntilIdle();
+                let switchError: unknown;
+                try {
+                    await this.options.notesModelService.switchProvider(settings);
+                } catch (error) {
+                    switchError = error;
+                }
+
+                if (current.codeModeEnabled) {
+                    this.indexingService?.startLoop();
+                }
+                if (switchError) {
+                    throw switchError;
+                }
+            }
+        );
+    }
+
+    async reindex(): Promise<void> {
+        if (this.options.settingsService.get().codeModeEnabled) {
+            await this.initialize(false);
+        }
+    }
+
+    async retryErrored(): Promise<void> {
+        await this.changeQueue?.retryErrored();
+    }
+
+    async applyExclusionPatterns(): Promise<void> {
+        await this.changeQueue?.applyExclusionPatterns();
+    }
+
+    setLogLevel(level: log.LogLevelDesc): void {
+        if (this.modelService && !this.sharesNotesModelService) {
+            this.modelService.setLogLevel(level);
+        }
+        this.chunkRepository?.setLogLevel(level);
+    }
+
+    async dispose(clearIndex = false): Promise<void> {
+        await this.options.similarNoteCoordinator.runSearchTransition(
+            "code",
+            async () => this.teardown(clearIndex)
+        );
+    }
+
+    private async teardown(clearIndex: boolean): Promise<void> {
+        this.indexingService?.stopLoop();
+        await this.indexingService?.waitUntilIdle();
+        this.changeQueue?.cleanup();
+
+        if (clearIndex && this.chunkRepository && this.modelService) {
+            // @ts-expect-error - appId exists at runtime but not in type definitions
+            const vaultId = this.options.app.appId as string;
+            await this.chunkRepository.init(
+                this.modelService.getVectorSize(),
+                vaultId,
+                false
+            );
+            await Promise.all([
+                this.indexedNotesMTimeStore?.clear(),
+                this.erroredNoteStore?.clear(),
+            ]);
+        }
+
+        this.indexedNotesMTimeStore?.close();
+        this.erroredNoteStore?.close();
+        await this.chunkRepository?.dispose();
+        if (this.modelService && !this.sharesNotesModelService) {
+            await this.modelService.disposeWhenIdle();
+        }
+
+        this.options.similarNoteCoordinator.setCodeSimilarNoteFinder(undefined);
+        this.chunkRepository = undefined;
+        this.changeQueue = undefined;
+        this.modelService = undefined;
+        this.similarNoteFinder = undefined;
+        this.textSearchService = undefined;
+        this.indexingService = undefined;
+        this.indexedNotesMTimeStore = undefined;
+        this.erroredNoteStore = undefined;
+        this.sharesNotesModelService = false;
+    }
+
+    private async disableCodeGPU(): Promise<void> {
+        const settings = this.options.settingsService.get();
+        const codeModel = settings.codeModel
+            ? { ...settings.codeModel }
+            : snapshotNoteModelSettings(settings);
+        await this.options.settingsService.update({
+            codeModel: { ...codeModel, useGPU: false },
+        });
+    }
+
+    private warnAboutTwoBuiltinModels(
+        notesModel: EmbeddingModelSettings,
+        codeModel: EmbeddingModelSettings
+    ): void {
+        if (
+            Platform.isMobileApp &&
+            notesModel.modelProvider === "builtin" &&
+            codeModel.modelProvider === "builtin"
+        ) {
+            new Notice(
+                "Code Mode is loading a second built-in model. This may exceed mobile memory; a remote Code model is recommended.",
+                8000
+            );
+        }
+    }
+}

--- a/src/application/NoteBottomViewManager.ts
+++ b/src/application/NoteBottomViewManager.ts
@@ -70,7 +70,10 @@ export class NoteBottomViewManager extends BaseViewManager<NoteBottomView> {
                 this.app.vault.getName(),
                 view,
                 embeddedBacklinksContainer.parentElement,
-                this.similarNoteCoordinator.getNoteBottomViewModelObservable()
+                this.similarNoteCoordinator.getNoteBottomViewModelObservable(),
+                (mode) => {
+                    void this.similarNoteCoordinator.setSearchMode(mode);
+                }
             );
 
             // Move similar notes container before embedded backlinks container

--- a/src/application/NoteIndexingService.ts
+++ b/src/application/NoteIndexingService.ts
@@ -2,6 +2,7 @@ import type { SettingsService } from "@/application/SettingsService";
 import type { NoteChunkRepository } from "@/domain/repository/NoteChunkRepository";
 import type { NoteRepository } from "@/domain/repository/NoteRepository";
 import type { EmbeddingService } from "@/domain/service/EmbeddingService";
+import { getChunkEmbeddingText } from "@/domain/service/chunkEmbeddingText";
 import type { NoteChunkingService } from "@/domain/service/NoteChunkingService";
 import type { ErroredNoteStore } from "@/infrastructure/ErroredNoteStore";
 import type { NoteChange, NoteChangeQueue } from "@/services/noteChangeQueue";
@@ -16,6 +17,8 @@ const MAX_ATTEMPTS = 3;
 export class NoteIndexingService {
     private fileChangeLoopTimer: NodeJS.Timeout | null = null;
     private noteChangeCount$ = new BehaviorSubject<number>(0);
+    private stopped = true;
+    private activeIteration?: Promise<void>;
 
     constructor(
         private noteRepository: NoteRepository,
@@ -23,14 +26,37 @@ export class NoteIndexingService {
         private noteChangeQueue: NoteChangeQueue,
         private noteChunkingService: NoteChunkingService,
         private embeddingService: EmbeddingService,
-        private similarNoteCoordinator: SimilarNoteCoordinator,
+        private similarNoteCoordinator: SimilarNoteCoordinator | undefined,
         private settingsService: SettingsService,
         private app: App,
-        private erroredNoteStore: ErroredNoteStore
+        private erroredNoteStore: ErroredNoteStore,
+        private indexKind: "notes" | "code" = "notes"
     ) {}
 
     startLoop() {
+        this.stopLoop();
+        this.stopped = false;
+        const scheduleIteration = () => {
+            if (this.stopped) return;
+            const iteration = fileChangeLoop();
+            this.activeIteration = iteration;
+            void iteration.then(
+                () => {
+                    if (this.activeIteration === iteration) {
+                        this.activeIteration = undefined;
+                    }
+                },
+                (error) => {
+                    if (this.activeIteration === iteration) {
+                        this.activeIteration = undefined;
+                    }
+                    log.error("[NoteIndexingService] Index loop failed", error);
+                }
+            );
+        };
         const fileChangeLoop = async () => {
+            if (this.stopped) return;
+
             const count = this.noteChangeQueue.getFileChangeCount();
             this.noteChangeCount$.next(count);
 
@@ -40,7 +66,11 @@ export class NoteIndexingService {
 
             const changes = await this.noteChangeQueue.pollFileChanges(concurrency);
             if (changes.length === 0) {
-                this.fileChangeLoopTimer = setTimeout(fileChangeLoop, 1000);
+                if (!this.stopped) {
+                    this.fileChangeLoopTimer = setTimeout(() => {
+                        scheduleIteration();
+                    }, 1000);
+                }
                 return;
             }
 
@@ -49,10 +79,12 @@ export class NoteIndexingService {
                 changes.map((change) => this.processChange(change))
             );
 
-            fileChangeLoop();
+            if (!this.stopped) {
+                scheduleIteration();
+            }
         };
 
-        fileChangeLoop();
+        scheduleIteration();
     }
 
     /**
@@ -85,9 +117,15 @@ export class NoteIndexingService {
     }
 
     stopLoop() {
+        this.stopped = true;
         if (this.fileChangeLoopTimer) {
             clearTimeout(this.fileChangeLoopTimer);
+            this.fileChangeLoopTimer = null;
         }
+    }
+
+    async waitUntilIdle(): Promise<void> {
+        await this.activeIteration;
     }
 
     /**
@@ -137,7 +175,7 @@ export class NoteIndexingService {
         await this.noteChunkRepository.removeByPath(path);
     }
 
-    private async processRenamedNote(change: NoteChange) {
+    private async processRenamedNote(change: NoteChange): Promise<void> {
         const { oldPath, path: newPath } = change;
         if (!oldPath) {
             // Defensive: a "renamed" change without oldPath is malformed.
@@ -168,20 +206,16 @@ export class NoteIndexingService {
         );
 
         // If the renamed file is the currently active one, refresh the sidebar.
-        const activeFile = this.app.workspace.getActiveFile();
-        if (activeFile && activeFile.path === newPath) {
-            this.similarNoteCoordinator.emitNoteBottomViewModelFromPath(
-                newPath
-            );
-        }
+        this.refreshActiveNote(newPath);
+
     }
 
-    private async processUpdatedNote(path: string) {
+    private async processUpdatedNote(path: string): Promise<void> {
         const note = await this.noteRepository.findByPath(
             path,
             !this.settingsService.get().includeFrontmatter
         );
-        if (!note || !note.content) {
+        if (!note) {
             return;
         }
 
@@ -189,12 +223,9 @@ export class NoteIndexingService {
         const settings = this.settingsService.get();
         const patterns = settings.excludeRegexPatterns || [];
 
-        // Create a copy of the note with filtered content
-        const filteredNote = { ...note };
-
         // Apply each regex pattern to exclude matching content
+        let filteredContent = note.content ?? "";
         if (patterns.length > 0) {
-            let filteredContent = note.content;
             for (const pattern of patterns) {
                 try {
                     const regex = new RegExp(pattern, "gm");
@@ -203,23 +234,26 @@ export class NoteIndexingService {
                     log.warn(`Invalid RegExp pattern: ${pattern}`, e);
                 }
             }
-            filteredNote.content = filteredContent;
+        }
+
+        // Create a copy of the note with exactly the content used for chunking.
+        const filteredNote = { ...note, content: filteredContent };
+
+        if (!filteredContent) {
+            await this.removeIndexedChunksAndRefreshActiveNote(note.path);
+            return;
         }
 
         const splitted = await this.noteChunkingService.split(filteredNote);
         if (splitted.length === 0) {
+            await this.removeIndexedChunksAndRefreshActiveNote(note.path);
             return;
         }
 
         log.info(`[NoteIndexingService] Generating embeddings for ${splitted.length} chunks (for indexing)`);
 
         // Prepare all texts for batch embedding
-        const textsToEmbed = splitted.map((chunk) =>
-            // Include title in first chunk to make it searchable
-            chunk.chunkIndex === 0
-                ? `${chunk.title}\n\n${chunk.content}`
-                : chunk.content
-        );
+        const textsToEmbed = splitted.map(getChunkEmbeddingText);
 
         // Single batch API call for all chunks. A failure here MUST propagate to
         // processChange's catch → handleChangeFailure (retry, then terminal
@@ -246,11 +280,33 @@ export class NoteIndexingService {
         const activeFile = this.app.workspace.getActiveFile();
         if (activeFile && activeFile.path === note.path) {
             log.info(`[NoteIndexingService] File is currently active, triggering similar note search`);
-            this.similarNoteCoordinator.emitNoteBottomViewModelFromPath(
-                note.path
-            );
+            this.refreshActiveNote(note.path);
         } else {
             log.info(`[NoteIndexingService] File is not currently active, skipping similar note search`);
         }
+
     }
+
+    private async removeIndexedChunksAndRefreshActiveNote(
+        path: string
+    ): Promise<void> {
+        await this.noteChunkRepository.removeByPath(path);
+
+        this.refreshActiveNote(path);
+    }
+
+    private refreshActiveNote(path: string): void {
+        const activeFile = this.app.workspace.getActiveFile();
+        if (
+            !activeFile ||
+            activeFile.path !== path ||
+            !this.similarNoteCoordinator ||
+            this.similarNoteCoordinator.getSearchMode() !== this.indexKind
+        ) {
+            return;
+        }
+
+        void this.similarNoteCoordinator.emitNoteBottomViewModelFromPath(path);
+    }
+
 }

--- a/src/application/SettingsService.ts
+++ b/src/application/SettingsService.ts
@@ -9,6 +9,29 @@ export interface CachedModelInfo {
     quantizationLevel?: string;   // Quantization level (for Ollama)
 }
 
+export type ModelProvider = "builtin" | "ollama" | "openai" | "gemini";
+export const CURRENT_CODE_INDEX_VERSION = 1;
+
+/**
+ * Complete configuration for one embedding model. SimilarNotesSettings keeps
+ * the existing note model fields at the top level for backwards compatibility,
+ * while optional secondary models can use this nested shape.
+ */
+export interface EmbeddingModelSettings {
+    modelProvider: ModelProvider;
+    modelId: string;
+    ollamaUrl?: string;
+    ollamaModel?: string;
+    openaiUrl?: string;
+    openaiApiKey?: string;
+    openaiModel?: string;
+    openaiMaxTokens?: number;
+    geminiApiKey?: string;
+    geminiModel?: string;
+    useGPU: boolean;
+    cachedModelInfo?: CachedModelInfo;
+}
+
 export interface DailyUsage {
     tokens: number;
     requestCount: number;
@@ -25,22 +48,16 @@ export interface UsageStats {
     total: TotalUsage;
 }
 
-export interface SimilarNotesSettings {
-    modelProvider: "builtin" | "ollama" | "openai" | "gemini"; // Model provider type
-    modelId: string; // The model ID to use for embeddings
-    ollamaUrl?: string; // Ollama server URL
-    ollamaModel?: string; // Ollama model name
-    openaiUrl?: string; // OpenAI-compatible server URL (default: https://api.openai.com/v1)
-    openaiApiKey?: string; // OpenAI API key
-    openaiModel?: string; // OpenAI model name (default: text-embedding-3-small)
-    openaiMaxTokens?: number; // Max tokens for custom OpenAI-compatible models (default: 8191)
+export interface SimilarNotesSettings extends EmbeddingModelSettings {
     openaiPricePerMillionTokens?: number; // Price per million tokens for cost estimation
-    geminiApiKey?: string; // Google Gemini API key
-    geminiModel?: string; // Gemini model name (default: text-embedding-004)
     usageStats?: UsageStats; // API usage statistics
+    codeModeEnabled: boolean; // Whether fenced code blocks are indexed separately
+    codeModel?: EmbeddingModelSettings; // Independent embedding model for code blocks
+    similarityMode: "notes" | "code"; // Active index for similar-note views
+    codeIndexVersion: number; // Extraction/chunking schema used by persisted code vectors
+    codeIndexFingerprint?: string; // Persisted Code vector schema/model identity
     includeFrontmatter: boolean; // Whether to include frontmatter in indexing
     showSourceChunk: boolean; // Whether to show the original chunk in the results
-    useGPU: boolean; // Whether to use GPU acceleration for model inference
     excludeFolderPatterns: string[]; // Glob patterns to exclude folders/files from indexing
     excludeRegexPatterns: string[]; // Regular expressions to exclude content from indexing
     regexpTestInputText: string; // Saved test input for RegExp testing
@@ -50,17 +67,62 @@ export interface SimilarNotesSettings {
     bottomResultCount: number; // Number of similar notes to show at bottom of notes
     minSimilarityThreshold: number; // Hide results below this cosine similarity (0..1, 0 = no filtering)
     lastPluginVersion?: string; // Last version of the plugin that was run
-    cachedModelInfo?: CachedModelInfo; // Cached model information
     indexingDelaySeconds: number; // Wait time after file changes before indexing
     semanticLinkTrigger: string; // Editor prefix that opens semantic link suggestions ([[? alternative). Empty = disabled.
 }
 
-const DEFAULT_SETTINGS: SimilarNotesSettings = {
-    modelProvider: "builtin", // Default to built-in models
+export const DEFAULT_EMBEDDING_MODEL_SETTINGS: Readonly<EmbeddingModelSettings> = {
+    modelProvider: "builtin",
     modelId: "sentence-transformers/all-MiniLM-L6-v2",
+    useGPU: true,
+};
+
+/** Create a detached model profile from the legacy top-level note settings. */
+export function snapshotNoteModelSettings(
+    settings: SimilarNotesSettings
+): EmbeddingModelSettings {
+    return {
+        modelProvider: settings.modelProvider,
+        modelId: settings.modelId,
+        ollamaUrl: settings.ollamaUrl,
+        ollamaModel: settings.ollamaModel,
+        openaiUrl: settings.openaiUrl,
+        openaiApiKey: settings.openaiApiKey,
+        openaiModel: settings.openaiModel,
+        openaiMaxTokens: settings.openaiMaxTokens,
+        geminiApiKey: settings.geminiApiKey,
+        geminiModel: settings.geminiModel,
+        useGPU: settings.useGPU,
+        cachedModelInfo: settings.cachedModelInfo
+            ? { ...settings.cachedModelInfo }
+            : undefined,
+    };
+}
+
+/**
+ * Fill fields omitted from a persisted nested profile without mutating either
+ * the profile or its fallback.
+ */
+export function normalizeEmbeddingModelSettings(
+    settings: Partial<EmbeddingModelSettings>,
+    fallback: Readonly<EmbeddingModelSettings> = DEFAULT_EMBEDDING_MODEL_SETTINGS
+): EmbeddingModelSettings {
+    const normalized = { ...fallback, ...settings };
+    return {
+        ...normalized,
+        cachedModelInfo: normalized.cachedModelInfo
+            ? { ...normalized.cachedModelInfo }
+            : undefined,
+    };
+}
+
+const DEFAULT_SETTINGS: SimilarNotesSettings = {
+    ...DEFAULT_EMBEDDING_MODEL_SETTINGS,
+    codeModeEnabled: false,
+    similarityMode: "notes",
+    codeIndexVersion: CURRENT_CODE_INDEX_VERSION,
     includeFrontmatter: false,
     showSourceChunk: false,
-    useGPU: true, // Use GPU acceleration by default
     // Excalidraw/ holds drawings stored as base64-compressed JSON — binary data
     // that can't be embedded and isn't meaningful to index (#46). Only applies to
     // new installs; existing users' saved patterns are untouched by the merge.
@@ -85,8 +147,19 @@ export class SettingsService {
     constructor(private plugin: Plugin) {}
 
     async load(): Promise<void> {
-        const data = await this.plugin.loadData();
-        this.settings = { ...DEFAULT_SETTINGS, ...data };
+        const data = (await this.plugin.loadData()) as
+            | (Partial<Omit<SimilarNotesSettings, "codeModel">> & {
+                  codeModel?: Partial<EmbeddingModelSettings>;
+              })
+            | null
+            | undefined;
+        this.settings = {
+            ...DEFAULT_SETTINGS,
+            ...data,
+            codeModel: data?.codeModel
+                ? normalizeEmbeddingModelSettings(data.codeModel)
+                : undefined,
+        };
 
         // For new mobile installations, default to OpenAI provider
         // Built-in models can cause crashes on mobile devices

--- a/src/application/SimilarNoteCoordinator.ts
+++ b/src/application/SimilarNoteCoordinator.ts
@@ -4,6 +4,9 @@ import type {
 } from "@/components/NoteBottomViewReact";
 import type { NoteRepository } from "@/domain/repository/NoteRepository";
 import type { SimilarNoteFinder } from "@/domain/service/SimilarNoteFinder";
+import type { TextSearch } from "@/domain/service/TextSearchService";
+import type { SearchMode } from "@/domain/model/SearchMode";
+import { AsyncOperationGate } from "@/utils/AsyncOperationGate";
 import log from "loglevel";
 import type { TFile, Vault } from "obsidian";
 import { BehaviorSubject } from "rxjs";
@@ -23,14 +26,22 @@ export class SimilarNoteCoordinator {
         noteDisplayMode: "title", // Will be properly initialized in constructor
         sidebarResultCount: 10,   // Will be properly initialized in constructor
         bottomResultCount: 5,     // Will be properly initialized in constructor
+        searchMode: "notes",
+        codeModeEnabled: false,
     });
     private cache = new Map<string, SimilarNoteCacheEntry>(); // file path -> entry
+    private viewRequestId = 0;
+    private readonly searchGates: Record<SearchMode, AsyncOperationGate> = {
+        notes: new AsyncOperationGate(),
+        code: new AsyncOperationGate(),
+    };
 
     constructor(
         private readonly vault: Vault,
         private readonly noteRepository: NoteRepository,
         private readonly similarNoteFinder: SimilarNoteFinder,
-        private readonly settingsService: SettingsService
+        private readonly settingsService: SettingsService,
+        private codeSimilarNoteFinder?: SimilarNoteFinder
     ) {
         // Initialize with current settings
         const settings = this.settingsService.get();
@@ -40,6 +51,8 @@ export class SimilarNoteCoordinator {
             noteDisplayMode: settings.noteDisplayMode,
             sidebarResultCount: settings.sidebarResultCount,
             bottomResultCount: settings.bottomResultCount,
+            searchMode: this.getSearchMode(),
+            codeModeEnabled: settings.codeModeEnabled,
         });
 
         this.settingsService
@@ -47,6 +60,19 @@ export class SimilarNoteCoordinator {
             .subscribe((newSettings) => {
                 if (newSettings.includeFrontmatter !== undefined) {
                     this.cache.clear();
+                }
+
+                if (
+                    newSettings.codeModeEnabled !== undefined ||
+                    newSettings.similarityMode !== undefined ||
+                    newSettings.codeModel !== undefined
+                ) {
+                    this.cache.clear();
+                    const file = this.noteBottomViewModel$.value.currentFile;
+                    if (file) {
+                        void this.emitNoteBottomViewModel(file);
+                        return;
+                    }
                 }
 
                 // Clear cache if result count settings changed (need to fetch more/fewer results)
@@ -73,8 +99,74 @@ export class SimilarNoteCoordinator {
                     noteDisplayMode: settings.noteDisplayMode,
                     sidebarResultCount: settings.sidebarResultCount,
                     bottomResultCount: settings.bottomResultCount,
+                    searchMode: this.getSearchMode(),
+                    codeModeEnabled: settings.codeModeEnabled,
                 });
             });
+    }
+
+    setCodeSimilarNoteFinder(finder: SimilarNoteFinder | undefined): void {
+        this.codeSimilarNoteFinder = finder;
+        this.cache.clear();
+        const file = this.noteBottomViewModel$.value.currentFile;
+        if (finder && file && this.getSearchMode() === "code") {
+            void this.emitNoteBottomViewModel(file);
+        }
+    }
+
+    async runSearchOperation<T>(
+        mode: SearchMode,
+        operation: () => Promise<T>
+    ): Promise<T> {
+        return await this.searchGates[mode].run(operation);
+    }
+
+    async runSearchTransition<T>(
+        mode: SearchMode,
+        operation: () => Promise<T>
+    ): Promise<T> {
+        return await this.searchGates[mode].transition(operation);
+    }
+
+    async closeSearchMode<T>(
+        mode: SearchMode,
+        operation: () => Promise<T>
+    ): Promise<T> {
+        return await this.searchGates[mode].close(
+            operation,
+            new Error(`${mode} search is unavailable because the plugin unloaded`)
+        );
+    }
+
+    coordinateTextSearch(mode: SearchMode, service: TextSearch): TextSearch {
+        return {
+            checkTokenLimit: (text) =>
+                this.runSearchOperation(mode, () =>
+                    service.checkTokenLimit(text)
+                ),
+            findSimilarNotesFromText: (text, limit) =>
+                this.runSearchOperation(mode, () =>
+                    service.findSimilarNotesFromText(text, limit)
+                ),
+        };
+    }
+
+    getSearchMode(): SearchMode {
+        const settings = this.settingsService.get();
+        if (!settings.codeModeEnabled) {
+            return "notes";
+        }
+        return settings.similarityMode ?? "notes";
+    }
+
+    async setSearchMode(mode: SearchMode): Promise<void> {
+        const settings = this.settingsService.get();
+        const nextMode = settings.codeModeEnabled ? mode : "notes";
+        if (this.getSearchMode() === nextMode) {
+            return;
+        }
+
+        await this.settingsService.update({ similarityMode: nextMode });
     }
 
     getNoteBottomViewModelObservable() {
@@ -83,6 +175,7 @@ export class SimilarNoteCoordinator {
 
     async onFileOpen(file: TFile | null) {
         if (!file || file.extension !== "md") {
+            this.viewRequestId += 1;
             // No active markdown file — clear the sidebar so it doesn't keep
             // showing similar notes for a file the user has navigated away from.
             const settings = this.settingsService.get();
@@ -92,6 +185,8 @@ export class SimilarNoteCoordinator {
                 noteDisplayMode: settings.noteDisplayMode,
                 sidebarResultCount: settings.sidebarResultCount,
                 bottomResultCount: settings.bottomResultCount,
+                searchMode: this.getSearchMode(),
+                codeModeEnabled: settings.codeModeEnabled,
             });
             return;
         }
@@ -105,11 +200,21 @@ export class SimilarNoteCoordinator {
             return;
         }
 
+        for (const key of this.cache.keys()) {
+            if (key.startsWith(`${path}:`)) {
+                this.cache.delete(key);
+            }
+        }
         await this.emitNoteBottomViewModel(file);
     }
 
     async emitNoteBottomViewModel(file: TFile) {
-        const similarNotes = await this.getSimilarNotes(file);
+        const requestId = ++this.viewRequestId;
+        const mode = this.getSearchMode();
+        const similarNotes = await this.getSimilarNotes(file, mode);
+        if (requestId !== this.viewRequestId || mode !== this.getSearchMode()) {
+            return;
+        }
         const settings = this.settingsService.get();
         const filtered = similarNotes.filter(
             (entry) => entry.similarity >= settings.minSimilarityThreshold
@@ -120,25 +225,50 @@ export class SimilarNoteCoordinator {
             noteDisplayMode: settings.noteDisplayMode,
             sidebarResultCount: settings.sidebarResultCount,
             bottomResultCount: settings.bottomResultCount,
+            searchMode: mode,
+            codeModeEnabled: settings.codeModeEnabled,
         });
     }
 
-    async getSimilarNotes(file: TFile): Promise<SimilarNoteEntry[]> {
-        const cacheEntry = this.cache.get(file.path);
+    async getSimilarNotes(
+        file: TFile,
+        mode: SearchMode = "notes"
+    ): Promise<SimilarNoteEntry[]> {
+        const settings = this.settingsService.get();
+        const effectiveMode =
+            mode === "code" && settings.codeModeEnabled ? "code" : "notes";
+        return await this.runSearchOperation(effectiveMode, () =>
+            this.getSimilarNotesForMode(file, effectiveMode)
+        );
+    }
+
+    private async getSimilarNotesForMode(
+        file: TFile,
+        effectiveMode: SearchMode
+    ): Promise<SimilarNoteEntry[]> {
+        const settings = this.settingsService.get();
+        const profileKey = this.getProfileCacheKey(effectiveMode);
+        const cacheKey = `${file.path}:${effectiveMode}:${profileKey}`;
+        const cacheEntry = this.cache.get(cacheKey);
         if (cacheEntry && cacheEntry.mtime === file.stat.mtime) {
             return cacheEntry.notes;
         }
 
-        const settings = this.settingsService.get();
         const note = await this.noteRepository.findByFile(
             file,
             !settings.includeFrontmatter
         );
         const maxResultCount = Math.max(settings.sidebarResultCount, settings.bottomResultCount);
-        const similarNotes = await this.similarNoteFinder.findSimilarNotes(
-            note,
-            maxResultCount
-        );
+        const finder =
+            effectiveMode === "code"
+                ? this.codeSimilarNoteFinder
+                : this.similarNoteFinder;
+        const similarNotes = finder
+            ? await finder.findSimilarNotes(
+                note,
+                maxResultCount
+            )
+            : [];
 
         const showSourceChunk = settings.showSourceChunk;
 
@@ -166,7 +296,7 @@ export class SimilarNoteCoordinator {
             })
             .map(({ path: _path, ...rest }) => rest) as SimilarNoteEntry[];
 
-        this.cache.set(file.path, {
+        this.cache.set(cacheKey, {
             mtime: file.stat.mtime,
             notes: similarNoteEntries,
         });
@@ -176,5 +306,24 @@ export class SimilarNoteCoordinator {
         }
 
         return similarNoteEntries;
+    }
+
+    private getProfileCacheKey(mode: SearchMode): string {
+        const settings = this.settingsService.get();
+        const profile = mode === "code" ? settings.codeModel : settings;
+        if (!profile) {
+            return "unconfigured";
+        }
+
+        const model =
+            profile.modelProvider === "builtin"
+                ? profile.modelId
+                : profile.modelProvider === "ollama"
+                    ? profile.ollamaModel
+                    : profile.modelProvider === "openai"
+                        ? profile.openaiModel
+                        : profile.geminiModel;
+        return [profile.modelProvider, model ?? "", profile.openaiMaxTokens ?? ""]
+            .join(":");
     }
 }

--- a/src/application/__tests__/CodeModeRuntime.test.ts
+++ b/src/application/__tests__/CodeModeRuntime.test.ts
@@ -1,0 +1,306 @@
+import type {
+    EmbeddingModelSettings,
+    SettingsService,
+    SimilarNotesSettings,
+} from "@/application/SettingsService";
+import type { NoteRepository } from "@/domain/repository/NoteRepository";
+import type { EmbeddingService } from "@/domain/service/EmbeddingService";
+import { FencedCodeBlockExtractor } from "@/infrastructure/FencedCodeBlockExtractor";
+import type { App } from "obsidian";
+import { describe, expect, test, vi } from "vitest";
+import { CodeModeRuntime } from "../CodeModeRuntime";
+import type { SimilarNoteCoordinator } from "../SimilarNoteCoordinator";
+
+vi.mock("@/domain/service/EmbeddingService", () => ({
+    EmbeddingService: class MockEmbeddingService {},
+}));
+
+function makeSettings(
+    overrides: Partial<SimilarNotesSettings> = {}
+): SimilarNotesSettings {
+    return {
+        modelProvider: "builtin",
+        modelId: "notes-model",
+        useGPU: false,
+        codeModeEnabled: false,
+        similarityMode: "notes",
+        codeIndexVersion: 1,
+        includeFrontmatter: false,
+        showSourceChunk: false,
+        excludeFolderPatterns: [],
+        excludeRegexPatterns: [],
+        regexpTestInputText: "",
+        noteDisplayMode: "smart",
+        showAtBottom: true,
+        sidebarResultCount: 10,
+        bottomResultCount: 5,
+        minSimilarityThreshold: 0,
+        indexingDelaySeconds: 1,
+        semanticLinkTrigger: ";;",
+        ...overrides,
+    };
+}
+
+function makeRuntime(initial: SimilarNotesSettings) {
+    let settings = initial;
+    const rebuildNotes = vi.fn().mockResolvedValue(undefined);
+    const settingsService = {
+        get: vi.fn(() => settings),
+        update: vi.fn(async (changes: Partial<SimilarNotesSettings>) => {
+            settings = { ...settings, ...changes };
+        }),
+    } as unknown as SettingsService;
+    const coordinator = {
+        setCodeSimilarNoteFinder: vi.fn(),
+        runSearchTransition: vi.fn(
+            async (_mode: string, operation: () => Promise<unknown>) =>
+                operation()
+        ),
+        runSearchOperation: vi.fn(
+            async (_mode: string, operation: () => Promise<unknown>) =>
+                operation()
+        ),
+    } as unknown as SimilarNoteCoordinator;
+    const runtime = new CodeModeRuntime({
+        app: { vault: {} } as unknown as App,
+        settingsService,
+        noteRepository: {} as NoteRepository,
+        notesModelService: {} as EmbeddingService,
+        similarNoteCoordinator: coordinator,
+        extractor: new FencedCodeBlockExtractor(),
+        rebuildNotesForModeToggle: rebuildNotes,
+    });
+    return { runtime, settingsService, rebuildNotes, getSettings: () => settings };
+}
+
+describe("CodeModeRuntime reindex decisions", () => {
+    const builtinCodeModel: EmbeddingModelSettings = {
+        modelProvider: "builtin",
+        modelId: "code-model",
+        useGPU: false,
+    };
+
+    test("enabling rebuilds Notes and starts a fresh Code index", async () => {
+        const { runtime, rebuildNotes, getSettings } = makeRuntime(makeSettings());
+        const initialize = vi
+            .spyOn(runtime as never, "initializeUnlocked")
+            .mockResolvedValue(undefined);
+
+        await runtime.applyChanges(true, builtinCodeModel);
+
+        expect(rebuildNotes).toHaveBeenCalledOnce();
+        expect(initialize).toHaveBeenCalledWith(false);
+        expect(getSettings().codeModeEnabled).toBe(true);
+    });
+
+    test("credential-only changes reload existing Code vectors", async () => {
+        const previous: EmbeddingModelSettings = {
+            modelProvider: "openai",
+            modelId: "unused",
+            openaiUrl: "https://example.test/v1",
+            openaiApiKey: "old",
+            openaiModel: "code-model",
+            useGPU: false,
+        };
+        const { runtime, rebuildNotes } = makeRuntime(
+            makeSettings({ codeModeEnabled: true, codeModel: previous })
+        );
+        const initialize = vi
+            .spyOn(runtime as never, "initializeUnlocked")
+            .mockResolvedValue(undefined);
+
+        await runtime.applyChanges(true, { ...previous, openaiApiKey: "new" });
+
+        expect(rebuildNotes).not.toHaveBeenCalled();
+        expect(initialize).toHaveBeenCalledWith(true);
+    });
+
+    test("changing the Code model rebuilds only the Code index", async () => {
+        const { runtime, rebuildNotes } = makeRuntime(
+            makeSettings({
+                codeModeEnabled: true,
+                codeModel: builtinCodeModel,
+            })
+        );
+        const initialize = vi
+            .spyOn(runtime as never, "initializeUnlocked")
+            .mockResolvedValue(undefined);
+
+        await runtime.applyChanges(true, {
+            ...builtinCodeModel,
+            modelId: "new-code-model",
+        });
+
+        expect(rebuildNotes).not.toHaveBeenCalled();
+        expect(initialize).toHaveBeenCalledWith(false);
+    });
+
+    test("disabling removes Code mode and restores Notes corpus", async () => {
+        const { runtime, rebuildNotes, getSettings } = makeRuntime(
+            makeSettings({
+                codeModeEnabled: true,
+                similarityMode: "code",
+                codeModel: builtinCodeModel,
+            })
+        );
+
+        await runtime.applyChanges(false, builtinCodeModel);
+
+        expect(rebuildNotes).toHaveBeenCalledOnce();
+        expect(getSettings().codeModeEnabled).toBe(false);
+        expect(getSettings().similarityMode).toBe("notes");
+    });
+
+    test("failed Code initialization restores the previous settings", async () => {
+        const initial = makeSettings();
+        const { runtime, getSettings } = makeRuntime(initial);
+        vi.spyOn(runtime as never, "initializeUnlocked").mockRejectedValueOnce(
+            new Error("invalid model")
+        );
+
+        await expect(
+            runtime.applyChanges(true, builtinCodeModel)
+        ).rejects.toThrow("invalid model");
+
+        expect(getSettings().codeModeEnabled).toBe(false);
+        expect(getSettings().codeModel).toBeUndefined();
+    });
+
+    test("a shared Code model detaches when Notes settings diverge", async () => {
+        const initial = makeSettings({
+            codeModeEnabled: true,
+            codeModel: {
+                modelProvider: "builtin",
+                modelId: "notes-model",
+                useGPU: false,
+            },
+        });
+        const { runtime, settingsService } = makeRuntime(initial);
+        const notesModelService = {
+            switchProvider: vi.fn().mockResolvedValue(undefined),
+        };
+        Object.assign(runtime as object, {
+            sharesNotesModelService: true,
+            indexingService: {
+                stopLoop: vi.fn(),
+                waitUntilIdle: vi.fn().mockResolvedValue(undefined),
+                startLoop: vi.fn(),
+            },
+        });
+        Object.assign(runtime["options"], { notesModelService });
+        await settingsService.update({ modelId: "new-notes-model" });
+        const initialize = vi
+            .spyOn(runtime as never, "initializeUnlocked")
+            .mockResolvedValue(undefined);
+
+        await runtime.switchNotesModel({
+            modelProvider: "builtin",
+            modelId: "new-notes-model",
+            useGPU: false,
+        });
+
+        expect(notesModelService.switchProvider).toHaveBeenCalledOnce();
+        expect(initialize).toHaveBeenCalledWith(true);
+    });
+
+    test("a failed shared-model detach does not switch the Notes model", async () => {
+        const initial = makeSettings({
+            codeModeEnabled: true,
+            codeModel: {
+                modelProvider: "builtin",
+                modelId: "notes-model",
+                useGPU: false,
+            },
+        });
+        const { runtime, settingsService } = makeRuntime(initial);
+        const notesModelService = {
+            switchProvider: vi.fn().mockResolvedValue(undefined),
+        };
+        Object.assign(runtime as object, { sharesNotesModelService: true });
+        Object.assign(runtime["options"], { notesModelService });
+        await settingsService.update({ modelId: "new-notes-model" });
+        const initialize = vi
+            .spyOn(runtime as never, "initializeUnlocked")
+            .mockRejectedValueOnce(new Error("old Code model unavailable"))
+            .mockResolvedValueOnce(undefined);
+
+        await expect(
+            runtime.switchNotesModel({
+                modelProvider: "builtin",
+                modelId: "new-notes-model",
+                useGPU: false,
+            })
+        ).rejects.toThrow("old Code model unavailable");
+
+        expect(initialize).toHaveBeenNthCalledWith(1, true);
+        expect(initialize).toHaveBeenNthCalledWith(2, true, true);
+        expect(notesModelService.switchProvider).not.toHaveBeenCalled();
+    });
+
+    test("teardown drains indexing and closes Code metadata stores", async () => {
+        const { runtime } = makeRuntime(
+            makeSettings({ codeModeEnabled: true })
+        );
+        const steps: string[] = [];
+        const syncStep = (name: string) =>
+            vi.fn(() => {
+                steps.push(name);
+            });
+        const asyncStep = (name: string) =>
+            vi.fn(async () => {
+                steps.push(name);
+            });
+        const chunkRepository = {
+            init: asyncStep("repository:init"),
+            dispose: asyncStep("repository:dispose"),
+        };
+        const indexedNotesMTimeStore = {
+            clear: asyncStep("mtimes:clear"),
+            close: syncStep("mtimes:close"),
+        };
+        const erroredNoteStore = {
+            clear: asyncStep("errors:clear"),
+            close: syncStep("errors:close"),
+        };
+        const modelService = {
+            getVectorSize: vi.fn(() => 384),
+            disposeWhenIdle: asyncStep("model:dispose"),
+        };
+
+        Object.assign(runtime["options"].app as object, {
+            appId: "vault-id",
+        });
+        Object.assign(runtime as object, {
+            indexingService: {
+                stopLoop: syncStep("indexing:stop"),
+                waitUntilIdle: asyncStep("indexing:drain"),
+            },
+            changeQueue: { cleanup: syncStep("queue:cleanup") },
+            chunkRepository,
+            indexedNotesMTimeStore,
+            erroredNoteStore,
+            modelService,
+            sharesNotesModelService: false,
+        });
+
+        await runtime.dispose(true);
+
+        expect(chunkRepository.init).toHaveBeenCalledWith(
+            384,
+            "vault-id",
+            false
+        );
+        expect(steps).toEqual([
+            "indexing:stop",
+            "indexing:drain",
+            "queue:cleanup",
+            "repository:init",
+            "mtimes:clear",
+            "errors:clear",
+            "mtimes:close",
+            "errors:close",
+            "repository:dispose",
+            "model:dispose",
+        ]);
+    });
+});

--- a/src/application/__tests__/NoteIndexingService.test.ts
+++ b/src/application/__tests__/NoteIndexingService.test.ts
@@ -71,10 +71,82 @@ function makeService() {
         queue,
         erroredStore,
         noteRepository,
+        noteChunkRepository,
         noteChunkingService,
         embeddingService,
     };
 }
+
+describe("NoteIndexingService lifecycle draining", () => {
+    test("waitUntilIdle includes an iteration paused in queue polling", async () => {
+        let resolvePoll!: (changes: NoteChange[]) => void;
+        const pollResult = new Promise<NoteChange[]>((resolve) => {
+            resolvePoll = resolve;
+        });
+        const noteChangeQueue = {
+            getFileChangeCount: vi.fn(() => 0),
+            pollFileChanges: vi.fn(() => pollResult),
+        };
+        const service = new NoteIndexingService(
+            {} as never,
+            {} as never,
+            noteChangeQueue as never,
+            {} as never,
+            { supportsParallelProcessing: vi.fn(() => false) } as never,
+            undefined,
+            {} as never,
+            {} as never,
+            {} as never
+        );
+
+        service.startLoop();
+        await vi.waitFor(() =>
+            expect(noteChangeQueue.pollFileChanges).toHaveBeenCalledOnce()
+        );
+        service.stopLoop();
+        let drained = false;
+        const drain = service.waitUntilIdle().then(() => {
+            drained = true;
+        });
+
+        await Promise.resolve();
+        expect(drained).toBe(false);
+        resolvePoll([]);
+        await drain;
+        expect(drained).toBe(true);
+    });
+});
+
+describe("NoteIndexingService empty Code corpus cleanup", () => {
+    test("removes stale chunks without embedding when splitting returns no chunks", async () => {
+        const {
+            service,
+            queue,
+            noteRepository,
+            noteChunkRepository,
+            noteChunkingService,
+            embeddingService,
+        } = makeService();
+        const change: NoteChange = {
+            path: "note.md",
+            reason: "modified",
+            mtime: 1234,
+        };
+        noteRepository.findByPath.mockResolvedValue({
+            path: "note.md",
+            content: "prose without fenced code",
+        });
+        noteChunkingService.split.mockResolvedValue([]);
+
+        await (service as unknown as ChangeProcessor).processChange(change);
+
+        expect(noteChunkRepository.removeByPath).toHaveBeenCalledWith(
+            "note.md"
+        );
+        expect(embeddingService.embedTexts).not.toHaveBeenCalled();
+        expect(queue.markNoteChangeProcessed).toHaveBeenCalledWith(change);
+    });
+});
 
 describe("NoteIndexingService retry/errored transition (indexing-status spec §3)", () => {
     let change: NoteChange;

--- a/src/application/__tests__/SettingsService.test.ts
+++ b/src/application/__tests__/SettingsService.test.ts
@@ -4,7 +4,10 @@ vi.mock("obsidian", () => ({
     Platform: { isMobileApp: false },
 }));
 
-import { SettingsService } from "../SettingsService";
+import {
+    SettingsService,
+    snapshotNoteModelSettings,
+} from "../SettingsService";
 import { shouldExcludeFile } from "@/utils/folderExclusion";
 
 describe("SettingsService defaults (spec item 4)", () => {
@@ -16,6 +19,103 @@ describe("SettingsService defaults (spec item 4)", () => {
         const svc = new SettingsService(plugin as never);
         await svc.load();
         expect(svc.get().semanticLinkTrigger).toBe(";;");
+    });
+
+    it("keeps Code Mode opt-in and leaves its model unset by default", async () => {
+        const plugin = {
+            loadData: vi.fn().mockResolvedValue(undefined),
+            saveData: vi.fn().mockResolvedValue(undefined),
+        };
+        const svc = new SettingsService(plugin as never);
+
+        await svc.load();
+
+        expect(svc.get().codeModeEnabled).toBe(false);
+        expect(svc.get().codeModel).toBeUndefined();
+    });
+
+    it("preserves legacy flat note-model settings", async () => {
+        const plugin = {
+            loadData: vi.fn().mockResolvedValue({
+                modelProvider: "ollama",
+                modelId: "legacy-builtin-model",
+                ollamaUrl: "http://embedding-host:11434",
+                ollamaModel: "nomic-embed-text",
+                useGPU: false,
+            }),
+            saveData: vi.fn().mockResolvedValue(undefined),
+        };
+        const svc = new SettingsService(plugin as never);
+
+        await svc.load();
+
+        expect(svc.get()).toMatchObject({
+            modelProvider: "ollama",
+            modelId: "legacy-builtin-model",
+            ollamaUrl: "http://embedding-host:11434",
+            ollamaModel: "nomic-embed-text",
+            useGPU: false,
+            codeModeEnabled: false,
+        });
+        expect(svc.get().codeModel).toBeUndefined();
+    });
+
+    it("deep-merges a persisted nested code model with model defaults", async () => {
+        const plugin = {
+            loadData: vi.fn().mockResolvedValue({
+                codeModeEnabled: true,
+                codeModel: {
+                    modelProvider: "openai",
+                    openaiModel: "code-embedding-model",
+                },
+            }),
+            saveData: vi.fn().mockResolvedValue(undefined),
+        };
+        const svc = new SettingsService(plugin as never);
+
+        await svc.load();
+
+        expect(svc.get().codeModel).toEqual({
+            modelProvider: "openai",
+            modelId: "sentence-transformers/all-MiniLM-L6-v2",
+            openaiModel: "code-embedding-model",
+            useGPU: true,
+            cachedModelInfo: undefined,
+        });
+    });
+
+    it("snapshots the current note model without sharing cached model state", async () => {
+        const plugin = {
+            loadData: vi.fn().mockResolvedValue({
+                modelProvider: "openai",
+                modelId: "legacy-builtin-model",
+                openaiUrl: "https://openrouter.ai/api/v1",
+                openaiApiKey: "test-key",
+                openaiModel: "text-embedding-3-small",
+                useGPU: false,
+                cachedModelInfo: {
+                    modelId: "text-embedding-3-small",
+                    embeddingLength: 1536,
+                },
+            }),
+            saveData: vi.fn().mockResolvedValue(undefined),
+        };
+        const svc = new SettingsService(plugin as never);
+        await svc.load();
+
+        const snapshot = snapshotNoteModelSettings(svc.get());
+
+        expect(snapshot).toMatchObject({
+            modelProvider: "openai",
+            openaiUrl: "https://openrouter.ai/api/v1",
+            openaiModel: "text-embedding-3-small",
+            useGPU: false,
+        });
+        const cachedModelInfo = snapshot.cachedModelInfo;
+        expect(cachedModelInfo).toBeDefined();
+        if (!cachedModelInfo) throw new Error("Expected cached model info");
+        cachedModelInfo.embeddingLength = 768;
+        expect(svc.get().cachedModelInfo?.embeddingLength).toBe(1536);
     });
 
     // Excalidraw notes are ~all binary drawing data (base64 compressed JSON),

--- a/src/application/__tests__/SimilarNoteCoordinator.test.ts
+++ b/src/application/__tests__/SimilarNoteCoordinator.test.ts
@@ -24,6 +24,9 @@ function makeSettings(
     return {
         modelProvider: "builtin",
         modelId: "test-model",
+        codeModeEnabled: false,
+        similarityMode: "notes",
+        codeIndexVersion: 1,
         includeFrontmatter: false,
         showSourceChunk: false,
         useGPU: false,
@@ -40,11 +43,20 @@ function makeSettings(
     };
 }
 
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((resolvePromise) => {
+        resolve = resolvePromise;
+    });
+    return { promise, resolve };
+}
+
 // eslint-disable-next-line max-lines-per-function
 describe("SimilarNoteCoordinator", () => {
     let vault: Vault;
     let noteRepository: NoteRepository;
     let similarNoteFinder: SimilarNoteFinder;
+    let codeSimilarNoteFinder: SimilarNoteFinder;
     let settingsService: SettingsService;
     let settings: SimilarNotesSettings;
 
@@ -71,11 +83,150 @@ describe("SimilarNoteCoordinator", () => {
         similarNoteFinder = {
             findSimilarNotes: vi.fn().mockResolvedValue([]),
         } as unknown as SimilarNoteFinder;
+        codeSimilarNoteFinder = {
+            findSimilarNotes: vi.fn().mockResolvedValue([]),
+        } as unknown as SimilarNoteFinder;
 
         settingsService = {
             get: vi.fn(() => settings),
             getNewSettingsObservable: vi.fn(() => settingsChange$),
         } as unknown as SettingsService;
+    });
+
+    describe("Code Mode routing", () => {
+        test("view queries the Code finder when Code Mode is selected", async () => {
+            settings = makeSettings({
+                codeModeEnabled: true,
+                similarityMode: "code",
+                codeModel: {
+                    modelProvider: "builtin",
+                    modelId: "code-model",
+                    useGPU: false,
+                },
+            });
+            const coord = new SimilarNoteCoordinator(
+                vault,
+                noteRepository,
+                similarNoteFinder,
+                settingsService,
+                codeSimilarNoteFinder
+            );
+
+            await coord.onFileOpen(makeFile("open.md"));
+
+            expect(codeSimilarNoteFinder.findSimilarNotes).toHaveBeenCalledOnce();
+            expect(similarNoteFinder.findSimilarNotes).not.toHaveBeenCalled();
+            expect(coord["noteBottomViewModel$"].value.searchMode).toBe("code");
+        });
+
+        test("public export-style lookup defaults to Notes mode", async () => {
+            settings = makeSettings({
+                codeModeEnabled: true,
+                similarityMode: "code",
+            });
+            const coord = new SimilarNoteCoordinator(
+                vault,
+                noteRepository,
+                similarNoteFinder,
+                settingsService,
+                codeSimilarNoteFinder
+            );
+
+            await coord.getSimilarNotes(makeFile("open.md"));
+
+            expect(similarNoteFinder.findSimilarNotes).toHaveBeenCalledOnce();
+            expect(codeSimilarNoteFinder.findSimilarNotes).not.toHaveBeenCalled();
+        });
+
+        test("Notes and Code results use separate cache entries", async () => {
+            settings = makeSettings({ codeModeEnabled: true });
+            const file = makeFile("open.md");
+            const coord = new SimilarNoteCoordinator(
+                vault,
+                noteRepository,
+                similarNoteFinder,
+                settingsService,
+                codeSimilarNoteFinder
+            );
+
+            await coord.getSimilarNotes(file, "notes");
+            await coord.getSimilarNotes(file, "code");
+            await coord.getSimilarNotes(file, "notes");
+            await coord.getSimilarNotes(file, "code");
+
+            expect(similarNoteFinder.findSimilarNotes).toHaveBeenCalledOnce();
+            expect(codeSimilarNoteFinder.findSimilarNotes).toHaveBeenCalledOnce();
+        });
+
+        test("a late Notes result cannot overwrite the selected Code mode", async () => {
+            settings = makeSettings({
+                codeModeEnabled: true,
+                similarityMode: "notes",
+            });
+            const file = makeFile("open.md");
+            const coord = new SimilarNoteCoordinator(
+                vault,
+                noteRepository,
+                similarNoteFinder,
+                settingsService,
+                codeSimilarNoteFinder
+            );
+            await coord.onFileOpen(file);
+
+            const notesResult = deferred<unknown[]>();
+            const codeResult = deferred<unknown[]>();
+            vi.mocked(similarNoteFinder.findSimilarNotes).mockReturnValue(
+                notesResult.promise as never
+            );
+            vi.mocked(codeSimilarNoteFinder.findSimilarNotes).mockReturnValue(
+                codeResult.promise as never
+            );
+            coord["cache"].clear();
+            const oldNotesRequest = coord.emitNoteBottomViewModel(file);
+            await vi.waitFor(() =>
+                expect(similarNoteFinder.findSimilarNotes).toHaveBeenCalledTimes(2)
+            );
+
+            settings = { ...settings, similarityMode: "code" };
+            settingsChange$.next({ similarityMode: "code" });
+            await vi.waitFor(() =>
+                expect(
+                    codeSimilarNoteFinder.findSimilarNotes
+                ).toHaveBeenCalledOnce()
+            );
+            codeResult.resolve([
+                {
+                    path: "code.md",
+                    title: "Code result",
+                    similarity: 0.9,
+                    similarChunk: "code",
+                    sourceChunk: "source",
+                    isLinked: false,
+                },
+            ]);
+            await vi.waitFor(() =>
+                expect(coord["noteBottomViewModel$"].value.searchMode).toBe(
+                    "code"
+                )
+            );
+
+            notesResult.resolve([
+                {
+                    path: "notes.md",
+                    title: "Late Notes result",
+                    similarity: 0.8,
+                    similarChunk: "notes",
+                    sourceChunk: "source",
+                    isLinked: false,
+                },
+            ]);
+            await oldNotesRequest;
+
+            expect(coord["noteBottomViewModel$"].value.searchMode).toBe("code");
+            expect(
+                coord["noteBottomViewModel$"].value.similarNoteEntries[0]?.title
+            ).toBe("Code result");
+        });
     });
 
     describe("#39.1: sidebar should not show stale results when the active note is closed", () => {

--- a/src/commands/SemanticSearchCommand.ts
+++ b/src/commands/SemanticSearchCommand.ts
@@ -1,6 +1,6 @@
 import type { App, Plugin } from "obsidian";
 import type { SettingsService } from "@/application/SettingsService";
-import type { TextSearchService } from "@/domain/service/TextSearchService";
+import type { TextSearch } from "@/domain/service/TextSearchService";
 import { SemanticSearchModal } from "@/components/SemanticSearchModal";
 import type { Command } from "./Command";
 
@@ -10,8 +10,9 @@ export class SemanticSearchCommand implements Command {
 
     constructor(
         private app: App,
-        private textSearchService: TextSearchService,
-        private settingsService: SettingsService
+        private textSearchService: TextSearch,
+        private settingsService: SettingsService,
+        private getCodeSearchService?: () => TextSearch | undefined
     ) {}
 
     register(plugin: Plugin): void {
@@ -26,10 +27,13 @@ export class SemanticSearchCommand implements Command {
             ],
             callback: () => {
                 const settings = this.settingsService.get();
+                const codeSearchService = this.getCodeSearchService?.();
                 const modal = new SemanticSearchModal(
                     this.app,
                     this.textSearchService,
-                    settings.noteDisplayMode
+                    settings.noteDisplayMode,
+                    codeSearchService,
+                    settings.codeModeEnabled && Boolean(codeSearchService)
                 );
                 modal.open();
             },

--- a/src/commands/createPluginCommands.ts
+++ b/src/commands/createPluginCommands.ts
@@ -1,0 +1,50 @@
+import type { SettingsService } from "@/application/SettingsService";
+import type { SimilarNoteCoordinator } from "@/application/SimilarNoteCoordinator";
+import type { TextSearch } from "@/domain/service/TextSearchService";
+import type MainPlugin from "@/main";
+import type { App } from "obsidian";
+import type { Command } from "./Command";
+import { ExportActiveNoteSimilarNotesCommand } from "./ExportActiveNoteSimilarNotesCommand";
+import { ReindexAllNotesCommand } from "./ReindexAllNotesCommand";
+import { RetryErroredNotesCommand } from "./RetryErroredNotesCommand";
+import { SemanticSearchCommand } from "./SemanticSearchCommand";
+import { ShowSimilarNotesCommand } from "./ShowSimilarNotesCommand";
+import { ToggleInDocumentViewCommand } from "./ToggleInDocumentViewCommand";
+
+interface PluginCommandDependencies {
+    plugin: MainPlugin;
+    app: App;
+    settingsService: SettingsService;
+    similarNoteCoordinator: SimilarNoteCoordinator;
+    notesTextSearch: TextSearch;
+    getCodeTextSearch: () => TextSearch | undefined;
+    manifestId: string;
+}
+
+export function createPluginCommands({
+    plugin,
+    app,
+    settingsService,
+    similarNoteCoordinator,
+    notesTextSearch,
+    getCodeTextSearch,
+    manifestId,
+}: PluginCommandDependencies): Command[] {
+    return [
+        new ShowSimilarNotesCommand(plugin),
+        new ToggleInDocumentViewCommand(settingsService),
+        new ReindexAllNotesCommand(plugin),
+        new RetryErroredNotesCommand(plugin),
+        new SemanticSearchCommand(
+            app,
+            notesTextSearch,
+            settingsService,
+            getCodeTextSearch
+        ),
+        new ExportActiveNoteSimilarNotesCommand(
+            app,
+            similarNoteCoordinator,
+            manifestId
+        ),
+    ];
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -5,3 +5,4 @@ export { ReindexAllNotesCommand } from "./ReindexAllNotesCommand";
 export { RetryErroredNotesCommand } from "./RetryErroredNotesCommand";
 export { SemanticSearchCommand } from "./SemanticSearchCommand";
 export { ExportActiveNoteSimilarNotesCommand } from "./ExportActiveNoteSimilarNotesCommand";
+export { createPluginCommands } from "./createPluginCommands";

--- a/src/components/BuiltinModelSettingsSection.tsx
+++ b/src/components/BuiltinModelSettingsSection.tsx
@@ -1,9 +1,9 @@
-import type { SimilarNotesSettings } from "@/application/SettingsService";
+import type { EmbeddingModelSettings } from "@/application/SettingsService";
 import type { ButtonComponent, Setting } from "obsidian";
 import type { SettingBuilder } from "./OpenAISettingsSection";
 
 export interface BuiltinModelSettingsSectionProps {
-    settings: SimilarNotesSettings;
+    settings: EmbeddingModelSettings;
     tempModelId: string | undefined;
     tempUseGPU: boolean | undefined;
     onModelIdChange: (value: string) => void;

--- a/src/components/CodeModelSettingsSection.tsx
+++ b/src/components/CodeModelSettingsSection.tsx
@@ -1,0 +1,354 @@
+import {
+    normalizeEmbeddingModelSettings,
+    snapshotNoteModelSettings,
+    type EmbeddingModelSettings,
+    type SettingsService,
+    type SimilarNotesSettings,
+} from "@/application/SettingsService";
+import {
+    embeddingProfilesEqual,
+    getEffectiveModelId,
+    getEmbeddingIndexFingerprint,
+} from "@/domain/service/embeddingProfile";
+import type MainPlugin from "@/main";
+import {
+    Notice,
+    Platform,
+    SettingGroup,
+    type App,
+    type ButtonComponent,
+} from "obsidian";
+import { getBuiltinModelSettingBuilders } from "./BuiltinModelSettingsSection";
+import { getGeminiSettingBuilders } from "./GeminiSettingsSection";
+import { getOllamaSettingBuilders } from "./OllamaSettingsSection";
+import {
+    getOpenAISettingBuilders,
+    type SettingBuilder,
+} from "./OpenAISettingsSection";
+
+interface CodeModelSettingsSectionProps {
+    containerEl: HTMLElement;
+    plugin: MainPlugin;
+    settingsService: SettingsService;
+    app: App;
+}
+
+export class CodeModelSettingsSection {
+    private sectionContainer?: HTMLElement;
+    private tempEnabled?: boolean;
+    private tempModel?: EmbeddingModelSettings;
+    private tempModelEdited = false;
+    private applyButton?: ButtonComponent;
+    private statusRefreshTimer?: ReturnType<typeof setInterval>;
+
+    constructor(private readonly props: CodeModelSettingsSectionProps) {}
+
+    render(): void {
+        this.stopStatusRefresh();
+        const settings = this.props.settingsService.get();
+        const model = this.getTempModel(settings);
+        this.tempEnabled ??= settings.codeModeEnabled;
+
+        if (!this.sectionContainer || !this.sectionContainer.parentElement) {
+            this.sectionContainer = this.props.containerEl.createDiv(
+                "code-model-settings-section"
+            );
+        } else {
+            this.sectionContainer.empty();
+        }
+
+        new SettingGroup(this.sectionContainer)
+            .setHeading("Code mode")
+            .addSetting((setting) => {
+                setting
+                    .setName("Index fenced code blocks separately")
+                    .setDesc(
+                        "Build a separate Code index. When enabled, fenced blocks are removed from the Notes index."
+                    )
+                    .addToggle((toggle) => {
+                        toggle
+                            .setValue(this.tempEnabled ?? false)
+                            .onChange((value) => {
+                                this.tempEnabled = value;
+                                setTimeout(() => this.render(), 150);
+                            });
+                    });
+            })
+            .addSetting((setting) => {
+                setting.setName("Code index status").setDesc(
+                    settings.codeModeEnabled
+                        ? "Loading Code index status…"
+                        : "Disabled"
+                );
+                if (settings.codeModeEnabled) {
+                    const refreshStatus = async () => {
+                        try {
+                            const status =
+                                await this.props.plugin.getCodeModeStatus();
+                            setting.setDesc(
+                                `${status.indexedNotes} notes, ${status.chunks} chunks, ${status.erroredNotes} errored`
+                            );
+                        } catch {
+                            setting.setDesc("Code index status unavailable");
+                        }
+                    };
+                    void refreshStatus();
+                    this.statusRefreshTimer = setInterval(
+                        () => void refreshStatus(),
+                        1500
+                    );
+                }
+            });
+
+        const modelGroup = new SettingGroup(this.sectionContainer)
+            .setHeading("Code model")
+            .addSetting((setting) => {
+                setting
+                    .setName("Configured model")
+                    .setDesc(
+                        `${model.modelProvider}: ${getEffectiveModelId(model)}`
+                    );
+            })
+            .addSetting((setting) => {
+                setting
+                    .setName("Model provider")
+                    .setDesc(
+                        "Choose the provider used only for fenced code blocks."
+                    )
+                    .addDropdown((dropdown) => {
+                        dropdown
+                            .addOption("builtin", "Built-in Models")
+                            .addOption("ollama", "Ollama")
+                            .addOption("openai", "OpenAI / Compatible")
+                            .addOption("gemini", "Google Gemini")
+                            .setValue(model.modelProvider)
+                            .onChange((value) => {
+                                this.updateModel({
+                                    modelProvider:
+                                        value as EmbeddingModelSettings["modelProvider"],
+                                });
+                                this.render();
+                            });
+                    });
+            });
+
+        this.getProviderBuilders(model).forEach((builder) =>
+            modelGroup.addSetting(builder)
+        );
+        modelGroup.addSetting((setting) => {
+            const hasChanges = this.hasChanges(settings);
+            const action = this.getActionLabel(settings);
+            setting
+                .setName(action)
+                .setDesc(
+                    hasChanges
+                        ? "Apply this Code Mode configuration. Required indexes will rebuild automatically."
+                        : "No Code Mode changes to apply."
+                )
+                .addButton((button) => {
+                    this.applyButton = button;
+                    button
+                        .setButtonText(action)
+                        .setDisabled(!hasChanges)
+                        .onClick(async () => {
+                            if (!this.hasChanges(this.props.settingsService.get())) {
+                                return;
+                            }
+                            button.setDisabled(true);
+                            try {
+                                await this.props.plugin.applyCodeModeChanges(
+                                    this.tempEnabled ?? false,
+                                    this.getTempModel(
+                                        this.props.settingsService.get()
+                                    )
+                                );
+                                new Notice("Code Mode settings applied");
+                                this.clearTempState();
+                                this.render();
+                            } catch (error) {
+                                console.error(
+                                    "Failed to apply Code Mode settings",
+                                    error
+                                );
+                                new Notice(
+                                    `Failed to apply Code Mode: ${
+                                        error instanceof Error
+                                            ? error.message
+                                            : String(error)
+                                    }`
+                                );
+                                this.updateApplyButton();
+                            }
+                        });
+                    if (hasChanges) button.setCta();
+                });
+        });
+    }
+
+    private getProviderBuilders(
+        model: EmbeddingModelSettings
+    ): SettingBuilder[] {
+        if (model.modelProvider === "builtin") {
+            return getBuiltinModelSettingBuilders({
+                settings: model,
+                tempModelId: model.modelId,
+                tempUseGPU: model.useGPU,
+                onModelIdChange: (modelId) => this.updateModel({ modelId }),
+                onUseGPUChange: (useGPU) => this.updateModel({ useGPU }),
+                onRender: () => this.render(),
+                updateApplyButtonState: () => this.updateApplyButton(),
+                isMobile: Platform.isMobileApp,
+            });
+        }
+        if (model.modelProvider === "ollama") {
+            const result = getOllamaSettingBuilders({
+                settings: model,
+                tempOllamaUrl: model.ollamaUrl,
+                tempOllamaModel: model.ollamaModel,
+                onOllamaUrlChange: (ollamaUrl) =>
+                    this.updateModel({ ollamaUrl }),
+                onOllamaModelChange: (ollamaModel) =>
+                    this.updateModel({ ollamaModel }),
+                updateApplyButtonState: () => this.updateApplyButton(),
+                onDropdownCreated: () => undefined,
+            });
+            setTimeout(() => {
+                void result.fetchModels();
+            }, 0);
+            return result.builders;
+        }
+        if (model.modelProvider === "openai") {
+            return getOpenAISettingBuilders({
+                settings: model,
+                tempOpenaiUrl: model.openaiUrl,
+                tempOpenaiApiKey: model.openaiApiKey,
+                tempOpenaiModel: model.openaiModel,
+                tempOpenaiMaxTokens: model.openaiMaxTokens,
+                onOpenaiUrlChange: (openaiUrl) =>
+                    this.updateModel({ openaiUrl }),
+                onOpenaiApiKeyChange: (openaiApiKey) =>
+                    this.updateModel({ openaiApiKey }),
+                onOpenaiModelChange: (openaiModel) =>
+                    this.updateModel({ openaiModel }),
+                onOpenaiMaxTokensChange: (openaiMaxTokens) =>
+                    this.updateModel({ openaiMaxTokens }),
+                onRender: () => this.render(),
+                getTempValues: () => ({
+                    url: this.tempModel?.openaiUrl,
+                    apiKey: this.tempModel?.openaiApiKey,
+                    model: this.tempModel?.openaiModel,
+                    maxTokens: this.tempModel?.openaiMaxTokens,
+                }),
+            });
+        }
+        return getGeminiSettingBuilders({
+            settings: model,
+            tempGeminiApiKey: model.geminiApiKey,
+            tempGeminiModel: model.geminiModel,
+            onGeminiApiKeyChange: (geminiApiKey) =>
+                this.updateModel({ geminiApiKey }),
+            onGeminiModelChange: (geminiModel) =>
+                this.updateModel({ geminiModel }),
+            onRender: () => this.render(),
+            getTempValues: () => ({
+                apiKey: this.tempModel?.geminiApiKey,
+                model: this.tempModel?.geminiModel,
+            }),
+        });
+    }
+
+    private getTempModel(
+        settings: SimilarNotesSettings
+    ): EmbeddingModelSettings {
+        if (
+            !this.tempModel ||
+            (!settings.codeModel && !this.tempModelEdited)
+        ) {
+            this.tempModel = settings.codeModel
+                ? normalizeEmbeddingModelSettings(
+                    settings.codeModel,
+                    snapshotNoteModelSettings(settings)
+                )
+                : snapshotNoteModelSettings(settings);
+        }
+        return this.tempModel;
+    }
+
+    private updateModel(
+        changes: Partial<EmbeddingModelSettings>
+    ): void {
+        const current = this.getTempModel(this.props.settingsService.get());
+        this.tempModel = { ...current, ...changes };
+        this.tempModelEdited = true;
+        this.updateApplyButton();
+    }
+
+    private hasChanges(settings: SimilarNotesSettings): boolean {
+        const currentModel = settings.codeModel
+            ? normalizeEmbeddingModelSettings(
+                settings.codeModel,
+                snapshotNoteModelSettings(settings)
+            )
+            : snapshotNoteModelSettings(settings);
+        return (
+            (this.tempEnabled ?? settings.codeModeEnabled) !==
+                settings.codeModeEnabled ||
+            !embeddingProfilesEqual(this.getTempModel(settings), currentModel)
+        );
+    }
+
+    private getActionLabel(settings: SimilarNotesSettings): string {
+        const enabled = this.tempEnabled ?? settings.codeModeEnabled;
+        if (enabled && !settings.codeModeEnabled) {
+            return "Enable & build code index";
+        }
+        if (!enabled && settings.codeModeEnabled) {
+            return "Disable & remove code index";
+        }
+        if (!enabled) return "Save code model";
+
+        const currentModel = settings.codeModel
+            ? normalizeEmbeddingModelSettings(
+                settings.codeModel,
+                snapshotNoteModelSettings(settings)
+            )
+            : snapshotNoteModelSettings(settings);
+        return getEmbeddingIndexFingerprint(this.getTempModel(settings)) ===
+            getEmbeddingIndexFingerprint(currentModel)
+            ? "Apply code model settings"
+            : "Apply & rebuild code index";
+    }
+
+    private updateApplyButton(): void {
+        if (!this.applyButton) return;
+        const settings = this.props.settingsService.get();
+        const hasChanges = this.hasChanges(settings);
+        this.applyButton
+            .setButtonText(this.getActionLabel(settings))
+            .setDisabled(!hasChanges);
+        if (hasChanges) {
+            this.applyButton.setCta();
+        } else {
+            this.applyButton.removeCta();
+        }
+    }
+
+    private clearTempState(): void {
+        this.tempEnabled = undefined;
+        this.tempModel = undefined;
+        this.tempModelEdited = false;
+        this.applyButton = undefined;
+    }
+
+    resetDraft(): void {
+        this.stopStatusRefresh();
+        this.clearTempState();
+    }
+
+    private stopStatusRefresh(): void {
+        if (this.statusRefreshTimer) {
+            clearInterval(this.statusRefreshTimer);
+            this.statusRefreshTimer = undefined;
+        }
+    }
+}

--- a/src/components/GeminiSettingsSection.tsx
+++ b/src/components/GeminiSettingsSection.tsx
@@ -1,12 +1,12 @@
 import { GeminiClient } from "@/adapter/gemini";
-import type { SimilarNotesSettings } from "@/application/SettingsService";
+import type { EmbeddingModelSettings } from "@/application/SettingsService";
 import { Notice } from "obsidian";
 import type { Setting } from "obsidian";
 
 export type SettingBuilder = (setting: Setting) => void;
 
 interface GeminiSettingsSectionProps {
-    settings: SimilarNotesSettings;
+    settings: EmbeddingModelSettings;
     tempGeminiApiKey: string | undefined;
     tempGeminiModel: string | undefined;
     onGeminiApiKeyChange: (value: string) => void;

--- a/src/components/NoteBottomView.ts
+++ b/src/components/NoteBottomView.ts
@@ -3,6 +3,7 @@ import { Component } from "obsidian";
 import * as React from "react";
 import { type Root, createRoot } from "react-dom/client";
 import type { Observable } from "rxjs";
+import type { SearchMode } from "@/domain/model/SearchMode";
 import NoteBottomViewReact, {
     type NoteBottomViewModel,
 } from "./NoteBottomViewReact";
@@ -16,7 +17,8 @@ export class NoteBottomView extends Component {
         private vaultName: string,
         private leaf: MarkdownView,
         private parentEl: HTMLElement,
-        private bottomViewModelSubject$: Observable<NoteBottomViewModel>
+        private bottomViewModelSubject$: Observable<NoteBottomViewModel>,
+        private onSearchModeChange?: (mode: SearchMode) => void
     ) {
         super();
         this.containerEl = parentEl.createDiv({
@@ -34,6 +36,7 @@ export class NoteBottomView extends Component {
                 leaf: this.leaf,
                 bottomViewModelSubject$: this.bottomViewModelSubject$,
                 viewType: "bottom",
+                onSearchModeChange: this.onSearchModeChange,
             })
         );
         return null;

--- a/src/components/NoteBottomViewReact.tsx
+++ b/src/components/NoteBottomViewReact.tsx
@@ -1,4 +1,5 @@
 import { getNoteDisplayText } from "@/utils/displayUtils";
+import type { SearchMode } from "@/domain/model/SearchMode";
 import type { MarkdownView, TFile, Workspace } from "obsidian";
 import { Menu } from "obsidian";
 import { useEffect, useLayoutEffect, useState } from "react";
@@ -19,11 +20,16 @@ export interface NoteBottomViewModel {
     noteDisplayMode: "title" | "path" | "smart";
     sidebarResultCount: number;
     bottomResultCount: number;
+    searchMode: SearchMode;
+    codeModeEnabled: boolean;
 }
 
 interface SimilarNotesHeaderProps {
     collapsed: boolean;
     onToggleCollapse: () => void;
+    searchMode: SearchMode;
+    codeModeEnabled: boolean;
+    onSearchModeChange?: (mode: SearchMode) => void;
 }
 
 export type ViewType = "sidebar" | "bottom";
@@ -34,12 +40,16 @@ interface NoteBottomViewProps {
     leaf: MarkdownView;
     bottomViewModelSubject$: Observable<NoteBottomViewModel>;
     viewType: ViewType;
+    onSearchModeChange?: (mode: SearchMode) => void;
 }
 
 // Header Component
 const SimilarNotesHeader: React.FC<SimilarNotesHeaderProps> = ({
     collapsed,
     onToggleCollapse,
+    searchMode,
+    codeModeEnabled,
+    onSearchModeChange,
 }) => {
     const handleKeyDown = (e: React.KeyboardEvent) => {
         if (e.key === "Enter" || e.key === " ") {
@@ -49,18 +59,35 @@ const SimilarNotesHeader: React.FC<SimilarNotesHeaderProps> = ({
     };
 
     return (
-        <div
-            className="tree-item-self is-clickable"
-            onClick={onToggleCollapse}
-            onKeyDown={handleKeyDown}
-        >
+        <div className="similar-notes-header tree-item-self">
             <div
                 className={`similar-notes-title tree-item-itself is-clickable ${
                     collapsed ? "is-collapsed" : ""
                 }`}
+                onClick={onToggleCollapse}
+                onKeyDown={handleKeyDown}
             >
                 <div className="tree-item-inner">Similar notes</div>
             </div>
+            {codeModeEnabled && !collapsed ? (
+                <div
+                    className="similar-notes-mode-switcher"
+                    role="group"
+                    aria-label="Similarity mode"
+                >
+                    {(["notes", "code"] as const).map((mode) => (
+                        <button
+                            key={mode}
+                            type="button"
+                            className={searchMode === mode ? "is-active" : ""}
+                            aria-pressed={searchMode === mode}
+                            onClick={() => onSearchModeChange?.(mode)}
+                        >
+                            {mode === "notes" ? "Notes" : "Code"}
+                        </button>
+                    ))}
+                </div>
+            ) : null}
         </div>
     );
 };
@@ -241,17 +268,21 @@ const SearchResultsContainer = ({
     onNoteClick,
     onContextMenu,
     noteDisplayMode,
+    searchMode,
 }: {
     similarNotes: SimilarNoteEntry[];
     onNoteClick: (e: React.MouseEvent, file: TFile) => void;
     onContextMenu: (e: React.MouseEvent, file: TFile) => void;
     noteDisplayMode: "title" | "path" | "smart";
+    searchMode: SearchMode;
 }) => {
     if (similarNotes.length === 0) {
         return (
             <div className="search-result-container">
                 <div className="search-empty-state">
-                    No similar notes found.
+                    {searchMode === "code"
+                        ? "No similar code blocks found."
+                        : "No similar notes found."}
                 </div>
             </div>
         );
@@ -282,12 +313,15 @@ const NoteBottomViewReact: React.FC<NoteBottomViewProps> = ({
     leaf,
     bottomViewModelSubject$,
     viewType,
+    onSearchModeChange,
 }) => {
     const [collapsed, setCollapsed] = useState(false);
     const [similarNotes, setSimilarNotes] = useState<SimilarNoteEntry[]>([]);
     const [noteDisplayMode, setNoteDisplayMode] = useState<
         "title" | "path" | "smart"
     >("title");
+    const [searchMode, setSearchMode] = useState<SearchMode>("notes");
+    const [codeModeEnabled, setCodeModeEnabled] = useState(false);
 
     useEffect(() => {
         const sub = bottomViewModelSubject$.subscribe((model: NoteBottomViewModel) => {
@@ -300,6 +334,8 @@ const NoteBottomViewReact: React.FC<NoteBottomViewProps> = ({
                 : model.bottomResultCount;
             setSimilarNotes(model.similarNoteEntries.slice(0, limit));
             setNoteDisplayMode(model.noteDisplayMode);
+            setSearchMode(model.searchMode);
+            setCodeModeEnabled(model.codeModeEnabled);
         });
         return () => sub.unsubscribe();
     }, [bottomViewModelSubject$, leaf.file, viewType]);
@@ -337,7 +373,7 @@ const NoteBottomViewReact: React.FC<NoteBottomViewProps> = ({
     };
 
     const toggleCollapse = () => {
-        setCollapsed(!collapsed);
+        setCollapsed((current) => !current);
     };
 
     return (
@@ -347,6 +383,9 @@ const NoteBottomViewReact: React.FC<NoteBottomViewProps> = ({
                 <SimilarNotesHeader
                     collapsed={collapsed}
                     onToggleCollapse={toggleCollapse}
+                    searchMode={searchMode}
+                    codeModeEnabled={codeModeEnabled}
+                    onSearchModeChange={onSearchModeChange}
                 />
                 {!collapsed && (
                     <SearchResultsContainer
@@ -354,6 +393,7 @@ const NoteBottomViewReact: React.FC<NoteBottomViewProps> = ({
                         onNoteClick={handleNoteClick}
                         onContextMenu={handleContextMenu}
                         noteDisplayMode={noteDisplayMode}
+                        searchMode={searchMode}
                     />
                 )}
             </div>

--- a/src/components/OllamaSettingsSection.tsx
+++ b/src/components/OllamaSettingsSection.tsx
@@ -1,11 +1,11 @@
 import { OllamaClient, type OllamaModelWithEmbeddingInfo } from "@/adapter/ollama";
-import type { SimilarNotesSettings } from "@/application/SettingsService";
+import type { EmbeddingModelSettings } from "@/application/SettingsService";
 import { Notice } from "obsidian";
 import type { DropdownComponent } from "obsidian";
 import type { SettingBuilder } from "./OpenAISettingsSection";
 
 interface OllamaSettingsSectionProps {
-    settings: SimilarNotesSettings;
+    settings: EmbeddingModelSettings;
     tempOllamaUrl: string | undefined;
     tempOllamaModel: string | undefined;
     onOllamaUrlChange: (value: string) => void;

--- a/src/components/OpenAISettingsSection.tsx
+++ b/src/components/OpenAISettingsSection.tsx
@@ -1,12 +1,12 @@
 import { OpenAIClient } from "@/adapter/openai";
-import type { SimilarNotesSettings } from "@/application/SettingsService";
+import type { EmbeddingModelSettings } from "@/application/SettingsService";
 import { Notice } from "obsidian";
 import type { Setting } from "obsidian";
 
 export type SettingBuilder = (setting: Setting) => void;
 
 interface OpenAISettingsSectionProps {
-    settings: SimilarNotesSettings;
+    settings: EmbeddingModelSettings;
     tempOpenaiUrl: string | undefined;
     tempOpenaiApiKey: string | undefined;
     tempOpenaiModel: string | undefined;

--- a/src/components/SemanticLinkSuggest.ts
+++ b/src/components/SemanticLinkSuggest.ts
@@ -12,7 +12,7 @@ import {
 import log from "loglevel";
 import type { SettingsService } from "@/application/SettingsService";
 import type { SimilarNote } from "@/domain/model/SimilarNote";
-import type { TextSearchService } from "@/domain/service/TextSearchService";
+import type { TextSearch } from "@/domain/service/TextSearchService";
 import { parseTrigger } from "./semanticLinkTrigger";
 import { resolveWikilink } from "./semanticSearchActions";
 
@@ -43,7 +43,7 @@ export class SemanticLinkSuggest extends EditorSuggest<SimilarNote> {
 
     constructor(
         app: App,
-        private readonly textSearchService: TextSearchService,
+        private readonly textSearchService: TextSearch,
         private readonly settingsService: SettingsService
     ) {
         super(app);

--- a/src/components/SemanticSearchModal.tsx
+++ b/src/components/SemanticSearchModal.tsx
@@ -4,15 +4,17 @@ import { Modal, Notice } from "obsidian";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import type { SimilarNote } from "@/domain/model/SimilarNote";
-import type { TextSearchService } from "@/domain/service/TextSearchService";
+import type { SearchMode } from "@/domain/model/SearchMode";
+import type { TextSearch } from "@/domain/service/TextSearchService";
 import {
     createNoteFromQuery,
     handleSemanticSearchKey,
     insertLinkForNote,
 } from "./semanticSearchActions";
-
-const MIN_SEARCH_LENGTH = 3;
-const DEBOUNCE_MS = 300;
+import {
+    MIN_SEARCH_LENGTH,
+    useSemanticSearch,
+} from "./useSemanticSearch";
 
 // Platform-specific modifier keys
 const isMac = typeof navigator !== "undefined" && navigator.platform.includes("Mac");
@@ -111,70 +113,54 @@ const SearchResultItem: React.FC<SearchResultItemProps> = ({
 
 interface SemanticSearchContentProps {
     app: App;
-    textSearchService: TextSearchService;
+    textSearchService: TextSearch;
+    codeSearchService?: TextSearch;
+    codeModeEnabled: boolean;
     noteDisplayMode: "title" | "path" | "smart";
     onClose: () => void;
 }
 
-function useSemanticSearch(textSearchService: TextSearchService) {
-    const [query, setQuery] = useState("");
-    const [results, setResults] = useState<SimilarNote[]>([]);
-    const [selectedIndex, setSelectedIndex] = useState(0);
-    const [isSearching, setIsSearching] = useState(false);
-    const [tokenWarning, setTokenWarning] = useState<string | null>(null);
-    const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-    const performSearch = useCallback(
-        async (searchQuery: string) => {
-            if (searchQuery.length < MIN_SEARCH_LENGTH) {
-                setResults([]);
-                setTokenWarning(null);
-                return;
-            }
-
-            setIsSearching(true);
-            try {
-                const searchResult =
-                    await textSearchService.findSimilarNotesFromText(searchQuery);
-
-                if (searchResult.isOverLimit) {
-                    setTokenWarning(
-                        `Text truncated: ${searchResult.tokenCount}→${searchResult.maxTokens} tokens`
-                    );
-                } else {
-                    setTokenWarning(null);
-                }
-                setResults(searchResult.similarNotes);
-                setSelectedIndex(0);
-            } catch (error) {
-                console.error("Search error:", error);
-                setResults([]);
-            } finally {
-                setIsSearching(false);
-            }
-        },
-        [textSearchService]
-    );
-
-    useEffect(() => {
-        if (debounceRef.current) clearTimeout(debounceRef.current);
-        debounceRef.current = setTimeout(() => performSearch(query), DEBOUNCE_MS);
-        return () => {
-            if (debounceRef.current) clearTimeout(debounceRef.current);
-        };
-    }, [query, performSearch]);
-
-    return { query, setQuery, results, selectedIndex, setSelectedIndex, isSearching, tokenWarning };
-}
+const SearchModeSwitcher: React.FC<{
+    searchMode: SearchMode;
+    onChange: (mode: SearchMode) => void;
+}> = ({ searchMode, onChange }) => (
+    <div
+        className="semantic-search-mode-switcher"
+        role="group"
+        aria-label="Semantic search mode"
+    >
+        {(["notes", "code"] as const).map((mode) => (
+            <button
+                key={mode}
+                type="button"
+                className={searchMode === mode ? "is-active" : ""}
+                aria-pressed={searchMode === mode}
+                onClick={() => onChange(mode)}
+            >
+                {mode === "notes" ? "Notes" : "Code"}
+            </button>
+        ))}
+    </div>
+);
 
 const SemanticSearchContent: React.FC<SemanticSearchContentProps> = ({
     app,
     textSearchService,
+    codeSearchService,
+    codeModeEnabled,
     noteDisplayMode,
     onClose,
 }) => {
-    const { query, setQuery, results, selectedIndex, setSelectedIndex, isSearching, tokenWarning } =
-        useSemanticSearch(textSearchService);
+    const [searchMode, setSearchMode] = useState<SearchMode>("notes");
+    const {
+        query, setQuery,
+        results,
+        selectedIndex,
+        setSelectedIndex,
+        isSearching,
+        tokenWarning,
+        invalidateSearch,
+    } = useSemanticSearch(textSearchService, codeSearchService, searchMode);
     const inputRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
@@ -246,15 +232,33 @@ const SemanticSearchContent: React.FC<SemanticSearchContentProps> = ({
         },
         [results, selectedIndex, setSelectedIndex, openNote, insertLink, createNote, onClose]
     );
+    const changeSearchMode = useCallback(
+        (mode: SearchMode) => {
+            if (mode === searchMode) return;
+            invalidateSearch();
+            setSearchMode(mode);
+        },
+        [invalidateSearch, searchMode]
+    );
 
     return (
         <div className="semantic-search-wrapper" onKeyDown={handleKeyDown}>
+            {codeModeEnabled && codeSearchService ? (
+                <SearchModeSwitcher
+                    searchMode={searchMode}
+                    onChange={changeSearchMode}
+                />
+            ) : null}
             <div className="prompt-input-container">
                 <input
                     ref={inputRef}
                     type="text"
                     className="prompt-input"
-                    placeholder="Search by semantic similarity..."
+                    placeholder={
+                        searchMode === "code"
+                            ? "Search fenced code blocks..."
+                            : "Search by semantic similarity..."
+                    }
                     value={query}
                     onChange={(e) => setQuery(e.target.value)}
                 />
@@ -274,7 +278,11 @@ const SemanticSearchContent: React.FC<SemanticSearchContentProps> = ({
                 {query.length >= MIN_SEARCH_LENGTH &&
                     !isSearching &&
                     results.length === 0 && (
-                    <div className="prompt-empty-state">No similar notes found</div>
+                    <div className="prompt-empty-state">
+                        {searchMode === "code"
+                            ? "No similar code blocks found"
+                            : "No similar notes found"}
+                    </div>
                 )}
                 {results.map((note, index) => {
                     const file = app.vault.getAbstractFileByPath(note.path) as TFile | null;
@@ -301,17 +309,23 @@ const SemanticSearchContent: React.FC<SemanticSearchContentProps> = ({
 
 export class SemanticSearchModal extends Modal {
     private root: Root | null = null;
-    private textSearchService: TextSearchService;
+    private textSearchService: TextSearch;
+    private codeSearchService?: TextSearch;
+    private codeModeEnabled: boolean;
     private noteDisplayMode: "title" | "path" | "smart";
 
     constructor(
         app: App,
-        textSearchService: TextSearchService,
-        noteDisplayMode: "title" | "path" | "smart"
+        textSearchService: TextSearch,
+        noteDisplayMode: "title" | "path" | "smart",
+        codeSearchService?: TextSearch,
+        codeModeEnabled = false
     ) {
         super(app);
         this.textSearchService = textSearchService;
         this.noteDisplayMode = noteDisplayMode;
+        this.codeSearchService = codeSearchService;
+        this.codeModeEnabled = codeModeEnabled;
     }
 
     onOpen() {
@@ -333,6 +347,8 @@ export class SemanticSearchModal extends Modal {
             <SemanticSearchContent
                 app={this.app}
                 textSearchService={this.textSearchService}
+                codeSearchService={this.codeSearchService}
+                codeModeEnabled={this.codeModeEnabled}
                 noteDisplayMode={this.noteDisplayMode}
                 onClose={() => this.close()}
             />

--- a/src/components/SimilarNotesSettingTab.tsx
+++ b/src/components/SimilarNotesSettingTab.tsx
@@ -8,6 +8,7 @@ import log from "loglevel";
 import { apiVersion, Notice, PluginSettingTab, SettingGroup, type Setting } from "obsidian";
 import type MainPlugin from "../main";
 import { ModelSettingsSection } from "./ModelSettingsSection";
+import { CodeModelSettingsSection } from "./CodeModelSettingsSection";
 import { IndexSettingsSection } from "./IndexSettingsSection";
 import type { SettingBuilder } from "./OpenAISettingsSection";
 
@@ -23,6 +24,7 @@ export class SimilarNotesSettingTab extends PluginSettingTab {
     private modelService?: EmbeddingService;
     private noteChunkRepository?: NoteChunkRepository;
     private modelSettingsSection?: ModelSettingsSection;
+    private codeModelSettingsSection?: CodeModelSettingsSection;
     private indexSettingsSection?: IndexSettingsSection;
 
     constructor(
@@ -156,6 +158,7 @@ export class SimilarNotesSettingTab extends PluginSettingTab {
         if (this.modelSettingsSection) {
             this.modelSettingsSection.destroy();
         }
+        this.codeModelSettingsSection?.resetDraft();
     }
 
     display(): void {
@@ -173,6 +176,16 @@ export class SimilarNotesSettingTab extends PluginSettingTab {
             });
         }
         this.modelSettingsSection.render();
+
+        if (!this.codeModelSettingsSection) {
+            this.codeModelSettingsSection = new CodeModelSettingsSection({
+                containerEl,
+                plugin: this.plugin,
+                settingsService: this.settingsService,
+                app: this.app,
+            });
+        }
+        this.codeModelSettingsSection.render();
 
         // Initialize and render index settings section
         if (!this.indexSettingsSection) {

--- a/src/components/SimilarNotesSidebarView.tsx
+++ b/src/components/SimilarNotesSidebarView.tsx
@@ -4,6 +4,7 @@ import type { WorkspaceLeaf } from "obsidian";
 import { ItemView } from "obsidian";
 import { createRoot, Root } from "react-dom/client";
 import type { Observable } from "rxjs";
+import type { SearchMode } from "@/domain/model/SearchMode";
 import NoteBottomViewReact, {
     type NoteBottomViewModel,
 } from "./NoteBottomViewReact";
@@ -14,7 +15,8 @@ export class SimilarNotesSidebarView extends ItemView {
 
     constructor(
         leaf: WorkspaceLeaf,
-        bottomViewModelSubject$: Observable<NoteBottomViewModel>
+        bottomViewModelSubject$: Observable<NoteBottomViewModel>,
+        private onSearchModeChange?: (mode: SearchMode) => void
     ) {
         super(leaf);
         this.bottomViewModelSubject$ = bottomViewModelSubject$;
@@ -49,6 +51,7 @@ export class SimilarNotesSidebarView extends ItemView {
                 leaf={mockLeaf}
                 bottomViewModelSubject$={this.bottomViewModelSubject$}
                 viewType="sidebar"
+                onSearchModeChange={this.onSearchModeChange}
             />
         );
     }

--- a/src/components/useSemanticSearch.ts
+++ b/src/components/useSemanticSearch.ts
@@ -1,0 +1,116 @@
+import type { SimilarNote } from "@/domain/model/SimilarNote";
+import type { SearchMode } from "@/domain/model/SearchMode";
+import type { TextSearch } from "@/domain/service/TextSearchService";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export const MIN_SEARCH_LENGTH = 3;
+const DEBOUNCE_MS = 300;
+
+export function useSemanticSearch(
+    textSearchService: TextSearch,
+    codeSearchService: TextSearch | undefined,
+    searchMode: SearchMode
+) {
+    const [query, setQueryState] = useState("");
+    const [results, setResults] = useState<SimilarNote[]>([]);
+    const [selectedIndex, setSelectedIndex] = useState(0);
+    const [isSearching, setIsSearching] = useState(false);
+    const [tokenWarning, setTokenWarning] = useState<string | null>(null);
+    const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const requestSequenceRef = useRef(0);
+    const activeSearchService =
+        searchMode === "code" ? codeSearchService : textSearchService;
+    const activeSearchServiceRef = useRef(activeSearchService);
+    activeSearchServiceRef.current = activeSearchService;
+
+    const invalidateSearch = useCallback(() => {
+        requestSequenceRef.current += 1;
+        setResults([]);
+        setSelectedIndex(0);
+        setTokenWarning(null);
+        setIsSearching(false);
+    }, []);
+    const setQuery = useCallback(
+        (value: string) => {
+            invalidateSearch();
+            setQueryState(value);
+        },
+        [invalidateSearch]
+    );
+
+    const performSearch = useCallback(
+        async (searchQuery: string, requestSequence: number) => {
+            if (
+                requestSequence !== requestSequenceRef.current ||
+                activeSearchServiceRef.current !== activeSearchService
+            ) {
+                return;
+            }
+            if (searchQuery.length < MIN_SEARCH_LENGTH) {
+                setResults([]);
+                setTokenWarning(null);
+                setIsSearching(false);
+                return;
+            }
+            if (!activeSearchService) {
+                setResults([]);
+                setTokenWarning("Code index is not available");
+                setIsSearching(false);
+                return;
+            }
+
+            setIsSearching(true);
+            try {
+                const searchResult =
+                    await activeSearchService.findSimilarNotesFromText(
+                        searchQuery
+                    );
+                if (
+                    requestSequence !== requestSequenceRef.current ||
+                    activeSearchServiceRef.current !== activeSearchService
+                ) {
+                    return;
+                }
+                setTokenWarning(
+                    searchResult.isOverLimit
+                        ? `Text truncated: ${searchResult.tokenCount}→${searchResult.maxTokens} tokens`
+                        : null
+                );
+                setResults(searchResult.similarNotes);
+                setSelectedIndex(0);
+            } catch (error) {
+                if (requestSequence !== requestSequenceRef.current) return;
+                console.error("Search error:", error);
+                setResults([]);
+            } finally {
+                if (requestSequence === requestSequenceRef.current) {
+                    setIsSearching(false);
+                }
+            }
+        },
+        [activeSearchService]
+    );
+
+    useEffect(() => {
+        const requestSequence = ++requestSequenceRef.current;
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        debounceRef.current = setTimeout(
+            () => performSearch(query, requestSequence),
+            DEBOUNCE_MS
+        );
+        return () => {
+            if (debounceRef.current) clearTimeout(debounceRef.current);
+        };
+    }, [query, performSearch]);
+
+    return {
+        query,
+        setQuery,
+        results,
+        selectedIndex,
+        setSelectedIndex,
+        isSearching,
+        tokenWarning,
+        invalidateSearch,
+    };
+}

--- a/src/domain/model/CodeBlock.ts
+++ b/src/domain/model/CodeBlock.ts
@@ -1,0 +1,22 @@
+export type FenceCharacter = "`" | "~";
+
+/**
+ * A fenced code block extracted from a Markdown note.
+ * Line numbers are one-based and include the opening/closing fences.
+ */
+export interface CodeBlock {
+    content: string;
+    language: string | null;
+    info: string;
+    blockIndex: number;
+    startLine: number;
+    endLine: number;
+    fenceCharacter: FenceCharacter;
+    fenceLength: number;
+    closed: boolean;
+}
+
+export interface ExtractedFencedCode {
+    prose: string;
+    codeBlocks: CodeBlock[];
+}

--- a/src/domain/model/CodeChunk.ts
+++ b/src/domain/model/CodeChunk.ts
@@ -1,0 +1,41 @@
+import { NoteChunk } from "./NoteChunk";
+
+/**
+ * A line-preserving piece of a fenced code block.
+ *
+ * CodeChunk extends NoteChunk so the existing vector repository can store it;
+ * the code-specific metadata remains available while embeddings are generated.
+ */
+export class CodeChunk extends NoteChunk {
+    constructor(
+        path: string,
+        title: string,
+        content: string,
+        chunkIndex: number,
+        totalChunks: number,
+        embedding: number[],
+        public readonly blockIndex: number,
+        public readonly blockChunkIndex: number,
+        public readonly totalBlockChunks: number,
+        public readonly language: string | null,
+        public readonly info: string
+    ) {
+        super(path, title, content, chunkIndex, totalChunks, embedding);
+    }
+
+    override withEmbedding(embedding: number[]): CodeChunk {
+        return new CodeChunk(
+            this.path,
+            this.title,
+            this.content,
+            this.chunkIndex,
+            this.totalChunks,
+            embedding,
+            this.blockIndex,
+            this.blockChunkIndex,
+            this.totalBlockChunks,
+            this.language,
+            this.info
+        );
+    }
+}

--- a/src/domain/model/SearchMode.ts
+++ b/src/domain/model/SearchMode.ts
@@ -1,0 +1,1 @@
+export type SearchMode = "notes" | "code";

--- a/src/domain/service/CodeChunkingService.ts
+++ b/src/domain/service/CodeChunkingService.ts
@@ -1,0 +1,9 @@
+import type { CodeBlock } from "@/domain/model/CodeBlock";
+import type { CodeChunk } from "@/domain/model/CodeChunk";
+import type { Note } from "@/domain/model/Note";
+
+export interface CodeChunkingService {
+    init(): Promise<void>;
+
+    split(note: Note, codeBlocks: CodeBlock[]): Promise<CodeChunk[]>;
+}

--- a/src/domain/service/EmbeddingService.ts
+++ b/src/domain/service/EmbeddingService.ts
@@ -1,4 +1,8 @@
-import type { SimilarNotesSettings, SettingsService } from "@/application/SettingsService";
+import type {
+    EmbeddingModelSettings,
+    SettingsService,
+} from "@/application/SettingsService";
+import { AsyncOperationGate } from "@/utils/AsyncOperationGate";
 import log from "loglevel";
 import { Subject, type Observable, type Subscription } from "rxjs";
 import { type EmbeddingProvider, type ModelInfo } from "./EmbeddingProvider";
@@ -23,7 +27,10 @@ export class EmbeddingService {
     private provider: EmbeddingProvider | null = null;
     private currentProviderType: "builtin" | "ollama" | "openai" | "gemini" | null = null;
 
-    constructor(private settingsService?: SettingsService) {}
+    constructor(
+        private settingsService?: SettingsService,
+        private onDisableGPU?: () => Promise<void>
+    ) {}
 
     // Proxy subjects that relay provider's observables
     private modelBusy$ = new Subject<boolean>();
@@ -34,11 +41,21 @@ export class EmbeddingService {
     private modelBusySubscription?: Subscription;
     private downloadProgressSubscription?: Subscription;
     private modelErrorSubscription?: Subscription;
+    private localOperationQueue: Promise<void> = Promise.resolve();
+    private readonly providerOperations = new AsyncOperationGate();
 
     /**
      * Switch to a different embedding provider based on settings
      */
-    async switchProvider(settings: SimilarNotesSettings): Promise<void> {
+    async switchProvider(settings: EmbeddingModelSettings): Promise<void> {
+        await this.providerOperations.transition(async () => {
+            await this.switchProviderUnlocked(settings);
+        });
+    }
+
+    private async switchProviderUnlocked(
+        settings: EmbeddingModelSettings
+    ): Promise<void> {
         const newProviderType = settings.modelProvider;
 
         // If same provider type and model, check if GPU settings changed for builtin provider
@@ -57,17 +74,9 @@ export class EmbeddingService {
                             : settings.geminiModel;
 
             if (currentModelId === targetModelId) {
-                // For builtin provider, GPU settings change requires reload
-                if (newProviderType === "builtin") {
-                    log.info(
-                        "Same model but GPU settings may have changed, continuing with provider switch"
-                    );
-                } else {
-                    log.info(
-                        "Same provider and model already loaded, skipping switch"
-                    );
-                    return;
-                }
+                log.info(
+                    "Same model selected; reloading so runtime configuration changes take effect"
+                );
             }
         }
 
@@ -78,21 +87,20 @@ export class EmbeddingService {
                 this.currentProviderType
             );
 
-            // Unsubscribe from current provider's observables
-            this.modelBusySubscription?.unsubscribe();
-            this.downloadProgressSubscription?.unsubscribe();
-            this.modelErrorSubscription?.unsubscribe();
-
-            this.provider.dispose();
-            this.provider = null;
+            this.disposeProvider();
         }
 
         // Create new provider
         if (newProviderType === "builtin") {
             log.info("Switching to Transformers embedding provider");
-            this.provider = new TransformersEmbeddingProvider(this.settingsService);
+            this.provider = new TransformersEmbeddingProvider(
+                this.settingsService,
+                this.onDisableGPU
+            );
             this.setupProviderSubscriptions();
-            await this.loadModel(settings.modelId, { useGPU: settings.useGPU });
+            await this.provider.loadModel(settings.modelId, {
+                useGPU: settings.useGPU,
+            });
         } else if (newProviderType === "ollama") {
             log.info("Switching to Ollama embedding provider");
             const ollamaConfig: OllamaConfig = {
@@ -101,7 +109,10 @@ export class EmbeddingService {
             };
             this.provider = new OllamaEmbeddingProvider(ollamaConfig);
             this.setupProviderSubscriptions();
-            await this.loadModel(settings.ollamaModel || "", ollamaConfig);
+            await this.provider.loadModel(
+                settings.ollamaModel || "",
+                ollamaConfig
+            );
         } else if (newProviderType === "openai") {
             log.info("Switching to OpenAI embedding provider");
             const openaiConfig: OpenAIConfig = {
@@ -113,7 +124,10 @@ export class EmbeddingService {
             };
             this.provider = new OpenAIEmbeddingProvider(openaiConfig);
             this.setupProviderSubscriptions();
-            await this.loadModel(settings.openaiModel || "text-embedding-3-small", openaiConfig);
+            await this.provider.loadModel(
+                settings.openaiModel || "text-embedding-3-small",
+                openaiConfig
+            );
         } else if (newProviderType === "gemini") {
             log.info("Switching to Gemini embedding provider");
             const geminiConfig: GeminiConfig = {
@@ -123,7 +137,10 @@ export class EmbeddingService {
             };
             this.provider = new GeminiEmbeddingProvider(geminiConfig);
             this.setupProviderSubscriptions();
-            await this.loadModel(settings.geminiModel || "gemini-embedding-001", geminiConfig);
+            await this.provider.loadModel(
+                settings.geminiModel || "gemini-embedding-001",
+                geminiConfig
+            );
         } else {
             throw new Error(`Unknown provider type: ${newProviderType}`);
         }
@@ -165,18 +182,18 @@ export class EmbeddingService {
         modelId: string,
         config?: TransformersConfig | OllamaConfig | OpenAIConfig | GeminiConfig
     ): Promise<ModelInfo> {
-        if (!this.provider) {
-            throw new Error("No embedding provider initialized");
-        }
-
-        return await this.provider.loadModel(modelId, config);
+        return await this.providerOperations.transition(async () => {
+            if (!this.provider) {
+                throw new Error("No embedding provider initialized");
+            }
+            return await this.provider.loadModel(modelId, config);
+        });
     }
 
     async unloadModel(): Promise<void> {
-        if (!this.provider) {
-            return;
-        }
-        await this.provider.unloadModel();
+        await this.providerOperations.transition(async () => {
+            await this.provider?.unloadModel();
+        });
     }
 
     getModelBusy$(): Observable<boolean> {
@@ -192,24 +209,51 @@ export class EmbeddingService {
     }
 
     async embedText(text: string): Promise<number[]> {
-        if (!this.provider) {
-            throw new Error("No embedding provider initialized");
-        }
-        return await this.provider.embedText(text);
+        return await this.runProviderOperation((provider) =>
+            provider.embedText(text)
+        );
     }
 
     async embedTexts(texts: string[]): Promise<number[][]> {
-        if (!this.provider) {
-            throw new Error("No embedding provider initialized");
-        }
-        return await this.provider.embedTexts(texts);
+        return await this.runProviderOperation((provider) =>
+            provider.embedTexts(texts)
+        );
     }
 
     async countTokens(text: string): Promise<number> {
-        if (!this.provider) {
-            throw new Error("No embedding provider initialized");
-        }
-        return await this.provider.countTokens(text);
+        return await this.runProviderOperation((provider) =>
+            provider.countTokens(text)
+        );
+    }
+
+    private async runProviderOperation<T>(
+        operation: (provider: EmbeddingProvider) => Promise<T>
+    ): Promise<T> {
+        return await this.providerOperations.run(async () => {
+            const provider = this.provider;
+            if (!provider) {
+                throw new Error("No embedding provider initialized");
+            }
+
+            if (provider.supportsParallelProcessing()) {
+                return await operation(provider);
+            }
+
+            const result = this.localOperationQueue.then(
+                () => operation(provider),
+                () => operation(provider)
+            );
+            this.localOperationQueue = result.then(
+                () => undefined,
+                () => undefined
+            );
+            return await result;
+        });
+    }
+
+    async waitUntilIdle(): Promise<void> {
+        await this.providerOperations.waitUntilIdle();
+        await this.localOperationQueue;
     }
 
     public getVectorSize(): number {
@@ -231,36 +275,34 @@ export class EmbeddingService {
      * Uses binary search for efficiency
      */
     async truncateToMaxTokens(text: string): Promise<string> {
-        if (!this.provider) {
-            throw new Error("No embedding provider initialized");
-        }
+        return await this.runProviderOperation(async (provider) => {
+            const maxTokens = provider.getMaxTokens();
+            const tokenCount = await provider.countTokens(text);
 
-        const maxTokens = this.provider.getMaxTokens();
-        const tokenCount = await this.provider.countTokens(text);
-
-        if (tokenCount <= maxTokens) {
-            return text;
-        }
-
-        // Binary search to find the right truncation point
-        let left = 0;
-        let right = text.length;
-        let result = "";
-
-        while (left < right) {
-            const mid = Math.floor((left + right + 1) / 2);
-            const truncated = text.substring(0, mid);
-            const count = await this.provider.countTokens(truncated);
-
-            if (count <= maxTokens) {
-                result = truncated;
-                left = mid;
-            } else {
-                right = mid - 1;
+            if (tokenCount <= maxTokens) {
+                return text;
             }
-        }
 
-        return result;
+            // Binary search to find the right truncation point
+            let left = 0;
+            let right = text.length;
+            let result = "";
+
+            while (left < right) {
+                const mid = Math.floor((left + right + 1) / 2);
+                const truncated = text.substring(0, mid);
+                const count = await provider.countTokens(truncated);
+
+                if (count <= maxTokens) {
+                    result = truncated;
+                    left = mid;
+                } else {
+                    right = mid - 1;
+                }
+            }
+
+            return result;
+        });
     }
 
     public isModelLoaded(): boolean {
@@ -276,6 +318,16 @@ export class EmbeddingService {
     }
 
     public dispose(): void {
+        this.disposeProvider();
+    }
+
+    async disposeWhenIdle(): Promise<void> {
+        await this.providerOperations.transition(async () => {
+            this.disposeProvider();
+        });
+    }
+
+    private disposeProvider(): void {
         // Clean up subscriptions
         this.modelBusySubscription?.unsubscribe();
         this.downloadProgressSubscription?.unsubscribe();

--- a/src/domain/service/SimilarNoteFinder.ts
+++ b/src/domain/service/SimilarNoteFinder.ts
@@ -6,6 +6,7 @@ import { SimilarNote } from "../model/SimilarNote";
 import type { NoteChunkRepository } from "../repository/NoteChunkRepository";
 import type { EmbeddingService } from "./EmbeddingService";
 import type { NoteChunkingService } from "./NoteChunkingService";
+import { getChunkEmbeddingText } from "./chunkEmbeddingText";
 
 export class SimilarNoteFinder {
     constructor(
@@ -35,12 +36,10 @@ export class SimilarNoteFinder {
             try {
                 noteChunks = await Promise.all(
                     splitted.map(async (chunk) => {
-                        // Include title in first chunk to make it searchable
-                        const textToEmbed = chunk.chunkIndex === 0
-                            ? `${chunk.title}\n\n${chunk.content}`
-                            : chunk.content;
                         return chunk.withEmbedding(
-                            await this.modelService.embedText(textToEmbed)
+                            await this.modelService.embedText(
+                                getChunkEmbeddingText(chunk)
+                            )
                         );
                     })
                 );

--- a/src/domain/service/TextSearchService.ts
+++ b/src/domain/service/TextSearchService.ts
@@ -11,7 +11,19 @@ export interface TextSearchResult {
     isOverLimit: boolean;
 }
 
-export class TextSearchService {
+export interface TextSearch {
+    checkTokenLimit(text: string): Promise<{
+        tokenCount: number;
+        maxTokens: number;
+        isOverLimit: boolean;
+    }>;
+    findSimilarNotesFromText(
+        text: string,
+        limit?: number
+    ): Promise<TextSearchResult>;
+}
+
+export class TextSearchService implements TextSearch {
     constructor(
         private readonly noteChunkRepository: NoteChunkRepository,
         private readonly embeddingService: EmbeddingService

--- a/src/domain/service/TransformersEmbeddingProvider.ts
+++ b/src/domain/service/TransformersEmbeddingProvider.ts
@@ -28,7 +28,10 @@ export class TransformersEmbeddingProvider implements EmbeddingProvider {
     private downloadProgress$ = new Subject<number>();
     private modelError$ = new Subject<string | null>();
 
-    constructor(private settingsService?: SettingsService) {
+    constructor(
+        private settingsService?: SettingsService,
+        private onDisableGPU?: () => Promise<void>
+    ) {
         this.workerManager = new WorkerManager<TransformersWorker>(
             "TransformersWorker"
         );
@@ -51,7 +54,11 @@ export class TransformersEmbeddingProvider implements EmbeddingProvider {
             return await this.tryLoadModel(modelId, useGPU);
         } catch (error) {
             // If GPU failed and we can retry with CPU
-            if (useGPU && isGPUError(error) && this.settingsService) {
+            if (
+                useGPU &&
+                isGPUError(error) &&
+                (this.settingsService || this.onDisableGPU)
+            ) {
                 log.info("GPU failed, retrying with CPU...");
                 new Notice("GPU failed, retrying with CPU...", 3000);
                 
@@ -104,7 +111,7 @@ export class TransformersEmbeddingProvider implements EmbeddingProvider {
     }
 
     private showGPUSettingModal(): void {
-        if (!this.settingsService) return;
+        if (!this.settingsService && !this.onDisableGPU) return;
 
         // We need the app instance for the modal, but we don't have direct access
         // Let's use a different approach - we'll add this to the global window temporarily
@@ -112,8 +119,11 @@ export class TransformersEmbeddingProvider implements EmbeddingProvider {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             (window as any).app, // Access global app instance
             async () => {
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                await this.settingsService!.update({ useGPU: false });
+                if (this.onDisableGPU) {
+                    await this.onDisableGPU();
+                    return;
+                }
+                await this.settingsService?.update({ useGPU: false });
             }
         );
         modal.open();

--- a/src/domain/service/__tests__/EmbeddingService.test.ts
+++ b/src/domain/service/__tests__/EmbeddingService.test.ts
@@ -157,6 +157,48 @@ describe("EmbeddingModelService", () => {
             expect(results[1]).toBe(5); // Math.ceil(18 / 4) = 5
             expect(results[2]).toBe(7); // Math.ceil(27 / 4) = 7
         });
+
+        it("drains old operations and blocks new ones during a provider switch", async () => {
+            let resolveEmbedding!: (embedding: number[]) => void;
+            const pendingEmbedding = new Promise<number[]>((resolve) => {
+                resolveEmbedding = resolve;
+            });
+            const oldProvider = {
+                supportsParallelProcessing: vi.fn(() => true),
+                embedText: vi.fn(() => pendingEmbedding),
+                embedTexts: vi.fn(),
+                isModelLoaded: vi.fn(() => false),
+                dispose: vi.fn(),
+            };
+            service.dispose();
+            Object.assign(service as object, {
+                provider: oldProvider,
+                currentProviderType: "ollama",
+            });
+
+            const active = service.embedText("active");
+            await vi.waitFor(() =>
+                expect(oldProvider.embedText).toHaveBeenCalledOnce()
+            );
+            const switching = service.switchProvider({
+                modelProvider: "builtin",
+                modelId: "new-model",
+                useGPU: false,
+            } as SimilarNotesSettings);
+            const later = service.embedTexts(["later"]);
+
+            await Promise.resolve();
+            expect(oldProvider.dispose).not.toHaveBeenCalled();
+            expect(oldProvider.embedText).toHaveBeenCalledOnce();
+
+            resolveEmbedding([1]);
+            await expect(active).resolves.toEqual([1]);
+            await switching;
+            expect(oldProvider.dispose).toHaveBeenCalledOnce();
+            await expect(later).resolves.toHaveLength(1);
+            expect(oldProvider.embedText).toHaveBeenCalledOnce();
+            expect(oldProvider.embedTexts).not.toHaveBeenCalled();
+        });
     });
 
     describe("unloadModel", () => {

--- a/src/domain/service/__tests__/embeddingProfile.test.ts
+++ b/src/domain/service/__tests__/embeddingProfile.test.ts
@@ -1,0 +1,68 @@
+import type { EmbeddingModelSettings } from "@/application/SettingsService";
+import { describe, expect, test } from "vitest";
+import {
+    embeddingProfilesEqual,
+    getEffectiveModelId,
+    getEmbeddingIndexFingerprint,
+} from "../embeddingProfile";
+
+describe("embedding profile identity", () => {
+    const profile: EmbeddingModelSettings = {
+        modelProvider: "openai",
+        modelId: "unused",
+        openaiUrl: "https://example.test/v1",
+        openaiApiKey: "secret-a",
+        openaiModel: "code-model",
+        openaiMaxTokens: 4096,
+        useGPU: false,
+    };
+
+    test("uses the provider-specific effective model ID", () => {
+        expect(getEffectiveModelId(profile)).toBe("code-model");
+    });
+
+    test("runtime equality includes credentials", () => {
+        expect(
+            embeddingProfilesEqual(profile, {
+                ...profile,
+                openaiApiKey: "secret-b",
+            })
+        ).toBe(false);
+    });
+
+    test("runtime equality ignores fields owned by inactive providers", () => {
+        const builtin: EmbeddingModelSettings = {
+            modelProvider: "builtin",
+            modelId: "local-model",
+            useGPU: false,
+            openaiApiKey: "old-note-key",
+        };
+        expect(
+            embeddingProfilesEqual(builtin, {
+                ...builtin,
+                openaiApiKey: "different-unused-key",
+            })
+        ).toBe(true);
+    });
+
+    test("index identity excludes credentials and GPU execution mode", () => {
+        expect(
+            getEmbeddingIndexFingerprint(profile)
+        ).toBe(
+            getEmbeddingIndexFingerprint({
+                ...profile,
+                openaiApiKey: "secret-b",
+                useGPU: true,
+            })
+        );
+    });
+
+    test("index identity changes with the embedding model", () => {
+        expect(getEmbeddingIndexFingerprint(profile)).not.toBe(
+            getEmbeddingIndexFingerprint({
+                ...profile,
+                openaiModel: "other-model",
+            })
+        );
+    });
+});

--- a/src/domain/service/chunkEmbeddingText.ts
+++ b/src/domain/service/chunkEmbeddingText.ts
@@ -1,0 +1,13 @@
+import { CodeChunk } from "@/domain/model/CodeChunk";
+import type { NoteChunk } from "@/domain/model/NoteChunk";
+
+export function getChunkEmbeddingText(chunk: NoteChunk): string {
+    if (chunk instanceof CodeChunk) {
+        const language = chunk.language ? `Language: ${chunk.language}\n` : "";
+        return `${chunk.title}\n${language}\n${chunk.content}`;
+    }
+
+    return chunk.chunkIndex === 0
+        ? `${chunk.title}\n\n${chunk.content}`
+        : chunk.content;
+}

--- a/src/domain/service/embeddingProfile.ts
+++ b/src/domain/service/embeddingProfile.ts
@@ -1,0 +1,66 @@
+import type { EmbeddingModelSettings } from "@/application/SettingsService";
+
+export function getEffectiveModelId(settings: EmbeddingModelSettings): string {
+    if (settings.modelProvider === "builtin") {
+        return settings.modelId;
+    }
+    if (settings.modelProvider === "ollama") {
+        return settings.ollamaModel ?? "";
+    }
+    if (settings.modelProvider === "openai") {
+        return settings.openaiModel ?? "text-embedding-3-small";
+    }
+    return settings.geminiModel ?? "gemini-embedding-001";
+}
+
+/** Runtime equality includes credentials and execution mode but is never logged. */
+export function embeddingProfilesEqual(
+    left: EmbeddingModelSettings,
+    right: EmbeddingModelSettings
+): boolean {
+    if (left.modelProvider !== right.modelProvider) {
+        return false;
+    }
+    if (getEffectiveModelId(left) !== getEffectiveModelId(right)) {
+        return false;
+    }
+
+    if (left.modelProvider === "builtin") {
+        return left.useGPU === right.useGPU;
+    }
+    if (left.modelProvider === "ollama") {
+        return (
+            (left.ollamaUrl ?? "http://localhost:11434") ===
+            (right.ollamaUrl ?? "http://localhost:11434")
+        );
+    }
+    if (left.modelProvider === "openai") {
+        return (
+            (left.openaiUrl ?? "https://api.openai.com/v1") ===
+                (right.openaiUrl ?? "https://api.openai.com/v1") &&
+            left.openaiApiKey === right.openaiApiKey &&
+            (left.openaiMaxTokens ?? 8191) ===
+                (right.openaiMaxTokens ?? 8191)
+        );
+    }
+    return left.geminiApiKey === right.geminiApiKey;
+}
+
+/**
+ * Persistable index identity. Credentials and GPU mode are intentionally absent:
+ * changing either reloads the provider but does not invalidate existing vectors.
+ */
+export function getEmbeddingIndexFingerprint(
+    settings: EmbeddingModelSettings
+): string {
+    const base = [settings.modelProvider, getEffectiveModelId(settings)];
+    if (settings.modelProvider === "ollama") {
+        base.push(settings.ollamaUrl ?? "http://localhost:11434");
+    } else if (settings.modelProvider === "openai") {
+        base.push(
+            settings.openaiUrl ?? "https://api.openai.com/v1",
+            String(settings.openaiMaxTokens ?? 8191)
+        );
+    }
+    return base.join(":");
+}

--- a/src/infrastructure/CodeAwareNoteChunkingService.ts
+++ b/src/infrastructure/CodeAwareNoteChunkingService.ts
@@ -1,0 +1,27 @@
+import type { SettingsService } from "@/application/SettingsService";
+import type { Note } from "@/domain/model/Note";
+import type { NoteChunk } from "@/domain/model/NoteChunk";
+import type { NoteChunkingService } from "@/domain/service/NoteChunkingService";
+import type { FencedCodeBlockExtractor } from "./FencedCodeBlockExtractor";
+
+/** Keeps legacy whole-Markdown chunking unless Code Mode owns fenced blocks. */
+export class CodeAwareNoteChunkingService implements NoteChunkingService {
+    constructor(
+        private readonly delegate: NoteChunkingService,
+        private readonly extractor: FencedCodeBlockExtractor,
+        private readonly settingsService: SettingsService
+    ) {}
+
+    async init(): Promise<void> {
+        await this.delegate.init();
+    }
+
+    async split(note: Note): Promise<NoteChunk[]> {
+        if (!this.settingsService.get().codeModeEnabled) {
+            return this.delegate.split(note);
+        }
+
+        const { prose } = this.extractor.extract(note.content ?? "");
+        return this.delegate.split({ ...note, content: prose });
+    }
+}

--- a/src/infrastructure/ErroredNoteStore.ts
+++ b/src/infrastructure/ErroredNoteStore.ts
@@ -14,7 +14,7 @@ export class ErroredNoteStore {
     private erroredCount$ = new BehaviorSubject<number>(0);
     private storage: IndexedDBErroredStorage;
 
-    constructor() {
+    constructor(private readonly namespace = "notes") {
         this.storage = new IndexedDBErroredStorage();
     }
 
@@ -23,7 +23,7 @@ export class ErroredNoteStore {
      * @param vaultId - Unique identifier for the vault (app.appId)
      */
     async init(vaultId: string): Promise<void> {
-        await this.storage.init(vaultId);
+        await this.storage.init(vaultId, this.namespace);
         this.entries = await this.storage.getAll();
         this.erroredCount$.next(Object.keys(this.entries).length);
         log.info(
@@ -92,5 +92,9 @@ export class ErroredNoteStore {
      */
     getCurrentErroredCount(): number {
         return this.erroredCount$.getValue();
+    }
+
+    close(): void {
+        this.storage.close();
     }
 }

--- a/src/infrastructure/FencedCodeBlockExtractor.ts
+++ b/src/infrastructure/FencedCodeBlockExtractor.ts
@@ -1,0 +1,157 @@
+import type {
+    CodeBlock,
+    ExtractedFencedCode,
+    FenceCharacter,
+} from "@/domain/model/CodeBlock";
+
+interface SourceLine {
+    text: string;
+    eol: string;
+}
+
+interface OpeningFence {
+    indentation: number;
+    character: FenceCharacter;
+    length: number;
+    info: string;
+    language: string | null;
+}
+
+/** Extract CommonMark-style fenced code blocks without changing other prose. */
+export class FencedCodeBlockExtractor {
+    extract(markdown: string): ExtractedFencedCode {
+        const lines = splitSourceLines(markdown);
+        const prose: string[] = [];
+        const codeBlocks: CodeBlock[] = [];
+
+        let lineIndex = 0;
+        while (lineIndex < lines.length) {
+            const opening = parseOpeningFence(lines[lineIndex].text);
+            if (!opening) {
+                prose.push(lines[lineIndex].text, lines[lineIndex].eol);
+                lineIndex++;
+                continue;
+            }
+
+            const closingIndex = findClosingFence(
+                lines,
+                lineIndex + 1,
+                opening
+            );
+            const contentEnd = closingIndex ?? lines.length;
+            const content = removeFinalLineEnding(
+                lines
+                    .slice(lineIndex + 1, contentEnd)
+                    .map(
+                        (line) =>
+                            removeUpToSpaces(
+                                line.text,
+                                opening.indentation
+                            ) + line.eol
+                    )
+                    .join("")
+            );
+
+            codeBlocks.push({
+                content,
+                language: opening.language,
+                info: opening.info,
+                blockIndex: codeBlocks.length,
+                startLine: lineIndex + 1,
+                endLine: closingIndex === null ? lines.length : closingIndex + 1,
+                fenceCharacter: opening.character,
+                fenceLength: opening.length,
+                closed: closingIndex !== null,
+            });
+
+            // Keep one line break where the block started. This prevents prose
+            // on either side of the removed block from being joined together.
+            prose.push(lines[lineIndex].eol);
+            lineIndex = closingIndex === null ? lines.length : closingIndex + 1;
+        }
+
+        return { prose: prose.join(""), codeBlocks };
+    }
+}
+
+function parseOpeningFence(line: string): OpeningFence | null {
+    const match = /^( {0,3})(`{3,}|~{3,})(.*)$/.exec(line);
+    if (!match) return null;
+
+    const marker = match[2];
+    const character = marker[0] as FenceCharacter;
+    const remainder = match[3];
+
+    // CommonMark forbids backticks in a backtick fence's info string.
+    if (character === "`" && remainder.includes("`")) return null;
+
+    const info = remainder.trim();
+    const language = info ? info.split(/[ \t]+/, 1)[0] : null;
+
+    return {
+        indentation: match[1].length,
+        character,
+        length: marker.length,
+        info,
+        language,
+    };
+}
+
+function findClosingFence(
+    lines: SourceLine[],
+    start: number,
+    opening: OpeningFence
+): number | null {
+    for (let index = start; index < lines.length; index++) {
+        if (isClosingFence(lines[index].text, opening)) return index;
+    }
+    return null;
+}
+
+function isClosingFence(line: string, opening: OpeningFence): boolean {
+    let index = 0;
+    while (index < line.length && index < 3 && line[index] === " ") index++;
+
+    const markerStart = index;
+    while (index < line.length && line[index] === opening.character) index++;
+
+    if (index - markerStart < opening.length) return false;
+    return /^[ \t]*$/.test(line.slice(index));
+}
+
+function removeUpToSpaces(line: string, count: number): string {
+    let removed = 0;
+    while (removed < count && line[removed] === " ") removed++;
+    return line.slice(removed);
+}
+
+function removeFinalLineEnding(content: string): string {
+    return content.replace(/(?:\r\n|\n|\r)$/, "");
+}
+
+function splitSourceLines(source: string): SourceLine[] {
+    const lines: SourceLine[] = [];
+    let start = 0;
+    let index = 0;
+
+    while (index < source.length) {
+        if (source[index] !== "\n" && source[index] !== "\r") {
+            index++;
+            continue;
+        }
+
+        const eol =
+            source[index] === "\r" && source[index + 1] === "\n"
+                ? "\r\n"
+                : source[index];
+        lines.push({ text: source.slice(start, index), eol });
+        index += eol.length;
+        start = index;
+    }
+
+    if (start < source.length || source.length === 0) {
+        lines.push({ text: source.slice(start), eol: "" });
+    }
+
+    return lines;
+}

--- a/src/infrastructure/FencedCodeNoteChunkingService.ts
+++ b/src/infrastructure/FencedCodeNoteChunkingService.ts
@@ -1,0 +1,22 @@
+import type { Note } from "@/domain/model/Note";
+import type { NoteChunk } from "@/domain/model/NoteChunk";
+import type { CodeChunkingService } from "@/domain/service/CodeChunkingService";
+import type { NoteChunkingService } from "@/domain/service/NoteChunkingService";
+import type { FencedCodeBlockExtractor } from "./FencedCodeBlockExtractor";
+
+/** Adapts fenced-code extraction to the existing note-indexing pipeline. */
+export class FencedCodeNoteChunkingService implements NoteChunkingService {
+    constructor(
+        private readonly extractor: FencedCodeBlockExtractor,
+        private readonly codeChunkingService: CodeChunkingService
+    ) {}
+
+    async init(): Promise<void> {
+        await this.codeChunkingService.init();
+    }
+
+    async split(note: Note): Promise<NoteChunk[]> {
+        const { codeBlocks } = this.extractor.extract(note.content ?? "");
+        return this.codeChunkingService.split(note, codeBlocks);
+    }
+}

--- a/src/infrastructure/IndexedDBChunkStorage.ts
+++ b/src/infrastructure/IndexedDBChunkStorage.ts
@@ -40,10 +40,13 @@ export class IndexedDBChunkStorage {
      * Initialize the IndexedDB database
      * Creates object stores and indexes if they don't exist
      * @param vaultId - Unique identifier for the vault (app.appId)
+     * @param namespace - Optional database namespace (for example, "code")
      */
-    async init(vaultId: string): Promise<void> {
+    async init(vaultId: string, namespace?: string): Promise<void> {
         // Use Obsidian's naming pattern: {vaultId}-{purpose}
-        this.dbName = `${vaultId}-similar-notes`;
+        this.dbName = namespace
+            ? `${vaultId}-similar-notes-${namespace}`
+            : `${vaultId}-similar-notes`;
         log.info(`Initializing IndexedDB: ${this.dbName}`);
         return new Promise((resolve, reject) => {
             const request = indexedDB.open(this.dbName, this.version);

--- a/src/infrastructure/IndexedDBErroredStorage.ts
+++ b/src/infrastructure/IndexedDBErroredStorage.ts
@@ -27,8 +27,9 @@ export class IndexedDBErroredStorage {
      * Initialize the IndexedDB database
      * @param vaultId - Unique identifier for the vault (app.appId)
      */
-    async init(vaultId: string): Promise<void> {
-        this.dbName = `${vaultId}-similar-notes-errored`;
+    async init(vaultId: string, namespace = "notes"): Promise<void> {
+        const namespaceSuffix = namespace === "notes" ? "" : `-${namespace}`;
+        this.dbName = `${vaultId}-similar-notes${namespaceSuffix}-errored`;
         log.info(`Initializing IndexedDB for errored notes: ${this.dbName}`);
 
         return new Promise((resolve, reject) => {

--- a/src/infrastructure/IndexedDBMTimeStorage.ts
+++ b/src/infrastructure/IndexedDBMTimeStorage.ts
@@ -32,9 +32,10 @@ export class IndexedDBMTimeStorage {
      * Initialize the IndexedDB database
      * @param vaultId - Unique identifier for the vault (app.appId)
      */
-    async init(vaultId: string): Promise<void> {
+    async init(vaultId: string, namespace = "notes"): Promise<void> {
         // Use Obsidian's naming pattern: {vaultId}-{purpose}
-        this.dbName = `${vaultId}-similar-notes-mtimes`;
+        const namespaceSuffix = namespace === "notes" ? "" : `-${namespace}`;
+        this.dbName = `${vaultId}-similar-notes${namespaceSuffix}-mtimes`;
         log.info(`Initializing IndexedDB for mtimes: ${this.dbName}`);
 
         return new Promise((resolve, reject) => {

--- a/src/infrastructure/IndexedNoteMTimeStore.ts
+++ b/src/infrastructure/IndexedNoteMTimeStore.ts
@@ -8,7 +8,7 @@ export class IndexedNoteMTimeStore {
     private storage: IndexedDBMTimeStorage;
     private vaultId = "";
 
-    constructor() {
+    constructor(private readonly namespace = "notes") {
         this.storage = new IndexedDBMTimeStorage();
     }
 
@@ -20,7 +20,7 @@ export class IndexedNoteMTimeStore {
         this.vaultId = vaultId;
 
         // Initialize IndexedDB storage
-        await this.storage.init(vaultId);
+        await this.storage.init(vaultId, this.namespace);
 
         // Load all mtimes from IndexedDB to memory cache
         this.mtimes = await this.storage.getAll();
@@ -88,6 +88,10 @@ export class IndexedNoteMTimeStore {
      */
     getCurrentIndexedNoteCount(): number {
         return this.indexedNoteCount$.getValue();
+    }
+
+    close(): void {
+        this.storage.close();
     }
 
     /**

--- a/src/infrastructure/LinePreservingCodeChunkingService.ts
+++ b/src/infrastructure/LinePreservingCodeChunkingService.ts
@@ -1,0 +1,146 @@
+import type { CodeBlock } from "@/domain/model/CodeBlock";
+import { CodeChunk } from "@/domain/model/CodeChunk";
+import type { Note } from "@/domain/model/Note";
+import type { CodeChunkingService } from "@/domain/service/CodeChunkingService";
+import type { EmbeddingService } from "@/domain/service/EmbeddingService";
+
+type TokenCounter = Pick<EmbeddingService, "countTokens" | "getMaxTokens">;
+
+interface PendingCodeChunk {
+    block: CodeBlock;
+    content: string;
+    blockChunkIndex: number;
+    totalBlockChunks: number;
+}
+
+/**
+ * Keeps complete source lines together whenever they fit. A single line is
+ * split only when that line alone exceeds the embedding model's token limit.
+ */
+export class LinePreservingCodeChunkingService implements CodeChunkingService {
+    constructor(private readonly embeddingService: TokenCounter) {}
+
+    async init(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    async split(note: Note, codeBlocks: CodeBlock[]): Promise<CodeChunk[]> {
+        const maxTokens = this.embeddingService.getMaxTokens();
+        if (!Number.isInteger(maxTokens) || maxTokens < 1) {
+            throw new Error(
+                `Code embedding model returned invalid max token count: ${maxTokens}`
+            );
+        }
+
+        const pending: PendingCodeChunk[] = [];
+        for (const block of codeBlocks) {
+            if (!block.content.trim()) continue;
+
+            const contents = await this.splitContent(block.content, maxTokens);
+            contents.forEach((content, blockChunkIndex) => {
+                pending.push({
+                    block,
+                    content,
+                    blockChunkIndex,
+                    totalBlockChunks: contents.length,
+                });
+            });
+        }
+
+        return pending.map(
+            ({ block, content, blockChunkIndex, totalBlockChunks }, index) =>
+                new CodeChunk(
+                    note.path,
+                    note.title,
+                    content,
+                    index,
+                    pending.length,
+                    [],
+                    block.blockIndex,
+                    blockChunkIndex,
+                    totalBlockChunks,
+                    block.language,
+                    block.info
+                )
+        );
+    }
+
+    private async splitContent(
+        content: string,
+        maxTokens: number
+    ): Promise<string[]> {
+        const chunks: string[] = [];
+        let current = "";
+
+        for (const line of splitIntoLineUnits(content)) {
+            const candidate = current + line;
+            if (
+                candidate &&
+                (await this.embeddingService.countTokens(candidate)) <= maxTokens
+            ) {
+                current = candidate;
+                continue;
+            }
+
+            if (current) {
+                chunks.push(current);
+                current = "";
+            }
+
+            if ((await this.embeddingService.countTokens(line)) <= maxTokens) {
+                current = line;
+                continue;
+            }
+
+            const pieces = await this.splitOversizedLine(line, maxTokens);
+            chunks.push(...pieces.slice(0, -1));
+            current = pieces[pieces.length - 1];
+        }
+
+        if (current) chunks.push(current);
+        return chunks;
+    }
+
+    private async splitOversizedLine(
+        line: string,
+        maxTokens: number
+    ): Promise<string[]> {
+        const pieces: string[] = [];
+        let remaining = line;
+
+        while (remaining) {
+            let low = 1;
+            let high = remaining.length;
+            let bestLength = 0;
+
+            while (low <= high) {
+                const midpoint = Math.floor((low + high) / 2);
+                const candidate = remaining.slice(0, midpoint);
+                const tokenCount =
+                    await this.embeddingService.countTokens(candidate);
+
+                if (tokenCount <= maxTokens) {
+                    bestLength = midpoint;
+                    low = midpoint + 1;
+                } else {
+                    high = midpoint - 1;
+                }
+            }
+
+            if (bestLength === 0) {
+                throw new Error(
+                    "Code embedding model cannot fit a single character within its token limit"
+                );
+            }
+
+            pieces.push(remaining.slice(0, bestLength));
+            remaining = remaining.slice(bestLength);
+        }
+
+        return pieces;
+    }
+}
+
+function splitIntoLineUnits(content: string): string[] {
+    return content.match(/[^\r\n]*(?:\r\n|\n|\r|$)/g)?.filter(Boolean) ?? [];
+}

--- a/src/infrastructure/__tests__/CodeAwareNoteChunkingService.test.ts
+++ b/src/infrastructure/__tests__/CodeAwareNoteChunkingService.test.ts
@@ -1,0 +1,58 @@
+import type { SettingsService } from "@/application/SettingsService";
+import { Note } from "@/domain/model/Note";
+import { NoteChunk } from "@/domain/model/NoteChunk";
+import type { NoteChunkingService } from "@/domain/service/NoteChunkingService";
+import { describe, expect, test, vi } from "vitest";
+import { CodeAwareNoteChunkingService } from "../CodeAwareNoteChunkingService";
+import { FencedCodeBlockExtractor } from "../FencedCodeBlockExtractor";
+
+function makeService(enabled: boolean) {
+    const seen: Note[] = [];
+    const delegate: NoteChunkingService = {
+        init: vi.fn().mockResolvedValue(undefined),
+        split: vi.fn(async (note: Note) => {
+            seen.push(note);
+            return [
+                new NoteChunk(note.path, note.title, note.content, 0, 1, []),
+            ];
+        }),
+    };
+    const settingsService = {
+        get: () => ({ codeModeEnabled: enabled }),
+    } as unknown as SettingsService;
+    return {
+        seen,
+        service: new CodeAwareNoteChunkingService(
+            delegate,
+            new FencedCodeBlockExtractor(),
+            settingsService
+        ),
+    };
+}
+
+describe("CodeAwareNoteChunkingService", () => {
+    test("preserves legacy Markdown when Code Mode is disabled", async () => {
+        const { service, seen } = makeService(false);
+        const markdown = "Before\n```ts\nconst x = 1;\n```\nAfter";
+
+        await service.split(new Note("note.md", "note", markdown, []));
+
+        expect(seen[0].content).toBe(markdown);
+    });
+
+    test("removes fenced blocks from the Notes corpus when enabled", async () => {
+        const { service, seen } = makeService(true);
+
+        await service.split(
+            new Note(
+                "note.md",
+                "note",
+                "Before\n```ts\nconst x = 1;\n```\nAfter",
+                []
+            )
+        );
+
+        expect(seen[0].content).toBe("Before\n\nAfter");
+        expect(seen[0].content).not.toContain("const x");
+    });
+});

--- a/src/infrastructure/__tests__/FencedCodeBlockExtractor.test.ts
+++ b/src/infrastructure/__tests__/FencedCodeBlockExtractor.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "vitest";
+import { FencedCodeBlockExtractor } from "../FencedCodeBlockExtractor";
+
+describe("FencedCodeBlockExtractor", () => {
+    const extractor = new FencedCodeBlockExtractor();
+
+    test("leaves Markdown without fenced blocks unchanged", () => {
+        const markdown = "# Heading\r\n\r\nPlain `inline code`.\r\n";
+
+        expect(extractor.extract(markdown)).toEqual({
+            prose: markdown,
+            codeBlocks: [],
+        });
+    });
+
+    test("extracts a backtick fence with language and info", () => {
+        const markdown = [
+            "Before",
+            "```ts title=example",
+            "const answer = 42;",
+            "```",
+            "After",
+        ].join("\n");
+
+        const result = extractor.extract(markdown);
+
+        expect(result.prose).toBe("Before\n\nAfter");
+        expect(result.codeBlocks).toEqual([
+            expect.objectContaining({
+                content: "const answer = 42;",
+                language: "ts",
+                info: "ts title=example",
+                blockIndex: 0,
+                startLine: 2,
+                endLine: 4,
+                fenceCharacter: "`",
+                fenceLength: 3,
+                closed: true,
+            }),
+        ]);
+    });
+
+    test("supports tilde fences and a longer closing fence", () => {
+        const markdown = [
+            "~~~~ python extra",
+            "print('hello')",
+            "~~~",
+            "~~~~~",
+        ].join("\n");
+
+        const result = extractor.extract(markdown);
+
+        expect(result.codeBlocks[0]).toEqual(
+            expect.objectContaining({
+                content: "print('hello')\n~~~",
+                language: "python",
+                info: "python extra",
+                fenceCharacter: "~",
+                fenceLength: 4,
+                closed: true,
+            })
+        );
+    });
+
+    test("accepts up to three spaces of fence indentation and removes that indentation from code", () => {
+        const markdown = [
+            "   ```js",
+            "   first();",
+            " second();",
+            "  ````",
+        ].join("\n");
+
+        const result = extractor.extract(markdown);
+
+        expect(result.codeBlocks[0].content).toBe("first();\nsecond();");
+    });
+
+    test("does not treat a four-space-indented fence as fenced code", () => {
+        const markdown = "    ```js\n    const value = 1;";
+
+        expect(extractor.extract(markdown)).toEqual({
+            prose: markdown,
+            codeBlocks: [],
+        });
+    });
+
+    test("extracts empty and unclosed blocks", () => {
+        const empty = extractor.extract(["Start", "```", "```", "End"].join("\n"));
+        const unclosed = extractor.extract(
+            ["Before", "~~~rust", "fn main() {}"].join("\n")
+        );
+
+        expect(empty.codeBlocks[0].content).toBe("");
+        expect(empty.codeBlocks[0].closed).toBe(true);
+        expect(empty.prose).toBe("Start\n\nEnd");
+
+        expect(unclosed.codeBlocks[0]).toEqual(
+            expect.objectContaining({
+                content: "fn main() {}",
+                language: "rust",
+                startLine: 2,
+                endLine: 3,
+                closed: false,
+            })
+        );
+        expect(unclosed.prose).toBe("Before\n\n");
+    });
+
+    test("rejects backticks in a backtick fence info string", () => {
+        const markdown = "```js`invalid";
+
+        expect(extractor.extract(markdown)).toEqual({
+            prose: markdown,
+            codeBlocks: [],
+        });
+    });
+});

--- a/src/infrastructure/__tests__/IndexedDBChunkStorage.test.ts
+++ b/src/infrastructure/__tests__/IndexedDBChunkStorage.test.ts
@@ -40,6 +40,62 @@ function describeInitialization(storage: () => IndexedDBChunkStorage) {
     });
 }
 
+function describeNamespaceIsolation() {
+    describe("Namespace Isolation", () => {
+        it("keeps the default and code indexes in separate databases", async () => {
+            const defaultStorage = new IndexedDBChunkStorage();
+            const codeStorage = new IndexedDBChunkStorage();
+
+            try {
+                await defaultStorage.init("namespace-test-vault");
+                await codeStorage.init("namespace-test-vault", "code");
+
+                expect(
+                    (
+                        defaultStorage as unknown as {
+                            dbName: string;
+                        }
+                    ).dbName
+                ).toBe("namespace-test-vault-similar-notes");
+                expect(
+                    (codeStorage as unknown as { dbName: string }).dbName
+                ).toBe("namespace-test-vault-similar-notes-code");
+
+                await defaultStorage.put(
+                    createMockChunk({
+                        path: "shared.md",
+                        content: "prose content",
+                    })
+                );
+                await codeStorage.put(
+                    createMockChunk({
+                        path: "shared.md",
+                        content: "code content",
+                    })
+                );
+
+                expect(await defaultStorage.count()).toBe(1);
+                expect(await codeStorage.count()).toBe(1);
+                expect(
+                    (await defaultStorage.getByPath("shared.md"))[0].content
+                ).toBe("prose content");
+                expect(
+                    (await codeStorage.getByPath("shared.md"))[0].content
+                ).toBe("code content");
+            } finally {
+                await defaultStorage.close();
+                await codeStorage.close();
+                indexedDB.deleteDatabase(
+                    "namespace-test-vault-similar-notes"
+                );
+                indexedDB.deleteDatabase(
+                    "namespace-test-vault-similar-notes-code"
+                );
+            }
+        });
+    });
+}
+
 function describeBasicCRUD(storage: () => IndexedDBChunkStorage) {
     describe("Basic CRUD Operations", () => {
         it("should store and count a single chunk", async () => {
@@ -316,6 +372,7 @@ describe("IndexedDBChunkStorage", () => {
     const getStorage = () => storage;
 
     describeInitialization(getStorage);
+    describeNamespaceIsolation();
     describeBasicCRUD(getStorage);
     describeBatchLoading(getStorage);
     describeMetadataStore(getStorage);

--- a/src/infrastructure/__tests__/LinePreservingCodeChunkingService.test.ts
+++ b/src/infrastructure/__tests__/LinePreservingCodeChunkingService.test.ts
@@ -1,0 +1,113 @@
+import type { CodeBlock } from "@/domain/model/CodeBlock";
+import { Note } from "@/domain/model/Note";
+import { describe, expect, test, vi } from "vitest";
+import { LinePreservingCodeChunkingService } from "../LinePreservingCodeChunkingService";
+
+function codeBlock(
+    content: string,
+    blockIndex = 0,
+    language: string | null = "ts"
+): CodeBlock {
+    return {
+        content,
+        language,
+        info: language ?? "",
+        blockIndex,
+        startLine: 1,
+        endLine: 1,
+        fenceCharacter: "`",
+        fenceLength: 3,
+        closed: true,
+    };
+}
+
+describe("LinePreservingCodeChunkingService", () => {
+    const note = new Note("src/example.md", "Example", "", []);
+
+    test("keeps complete lines together while they fit", async () => {
+        const counter = {
+            getMaxTokens: () => 11,
+            countTokens: vi.fn(async (text: string) => text.length),
+        };
+        const service = new LinePreservingCodeChunkingService(counter);
+
+        const chunks = await service.split(
+            note,
+            [codeBlock("alpha\nbeta\ngamma")]
+        );
+
+        expect(chunks.map((chunk) => chunk.content)).toEqual([
+            "alpha\nbeta\n",
+            "gamma",
+        ]);
+        expect(chunks.map((chunk) => chunk.chunkIndex)).toEqual([0, 1]);
+        expect(chunks.every((chunk) => chunk.totalChunks === 2)).toBe(true);
+    });
+
+    test("splits within a line only when that line exceeds the model limit", async () => {
+        const counter = {
+            getMaxTokens: () => 4,
+            countTokens: vi.fn(async (text: string) => text.length),
+        };
+        const service = new LinePreservingCodeChunkingService(counter);
+
+        const chunks = await service.split(note, [codeBlock("abcdefghij")]);
+
+        expect(chunks.map((chunk) => chunk.content)).toEqual([
+            "abcd",
+            "efgh",
+            "ij",
+        ]);
+        for (const chunk of chunks) {
+            expect(await counter.countTokens(chunk.content)).toBeLessThanOrEqual(4);
+        }
+    });
+
+    test("preserves block and language metadata with global and per-block indexes", async () => {
+        const counter = {
+            getMaxTokens: () => 6,
+            countTokens: vi.fn(async (text: string) => text.length),
+        };
+        const service = new LinePreservingCodeChunkingService(counter);
+
+        const chunks = await service.split(note, [
+            codeBlock("   ", 0),
+            codeBlock("one\ntwo\nthree", 1, "python"),
+            codeBlock("last", 2, null),
+        ]);
+
+        expect(chunks).toHaveLength(4);
+        expect(chunks.map((chunk) => chunk.chunkIndex)).toEqual([0, 1, 2, 3]);
+        expect(chunks.every((chunk) => chunk.totalChunks === 4)).toBe(true);
+        expect(chunks.slice(0, 3).map((chunk) => chunk.blockChunkIndex)).toEqual([
+            0, 1, 2,
+        ]);
+        expect(chunks.slice(0, 3).every((chunk) => chunk.totalBlockChunks === 3)).toBe(true);
+        expect(chunks[0]).toEqual(
+            expect.objectContaining({
+                blockIndex: 1,
+                language: "python",
+                info: "python",
+            })
+        );
+        expect(chunks[3]).toEqual(
+            expect.objectContaining({
+                blockIndex: 2,
+                language: null,
+                blockChunkIndex: 0,
+                totalBlockChunks: 1,
+            })
+        );
+    });
+
+    test("rejects invalid model token limits", async () => {
+        const service = new LinePreservingCodeChunkingService({
+            getMaxTokens: () => 0,
+            countTokens: async (text: string) => text.length,
+        });
+
+        await expect(service.split(note, [codeBlock("code")])).rejects.toThrow(
+            "invalid max token count"
+        );
+    });
+});

--- a/src/infrastructure/pluginDataFiles.ts
+++ b/src/infrastructure/pluginDataFiles.ts
@@ -1,0 +1,34 @@
+import log from "loglevel";
+import type { Vault } from "obsidian";
+
+export async function ensurePluginDataDir(
+    vault: Vault,
+    pluginId: string
+): Promise<string> {
+    const pluginDataDir = `${vault.configDir}/plugins/${pluginId}`;
+    if (!(await vault.adapter.exists(pluginDataDir))) {
+        await vault.adapter.mkdir(pluginDataDir);
+    }
+    return pluginDataDir;
+}
+
+export async function migrateDataFile(
+    vault: Vault,
+    oldPath: string,
+    newPath: string
+): Promise<void> {
+    try {
+        if (
+            (await vault.adapter.exists(oldPath)) &&
+            !(await vault.adapter.exists(newPath))
+        ) {
+            log.info(`Migrating file from ${oldPath} to ${newPath}`);
+            const data = await vault.adapter.read(oldPath);
+            await vault.adapter.write(newPath, data);
+            await vault.adapter.remove(oldPath);
+            log.info("Successfully migrated file to plugin folder");
+        }
+    } catch (error) {
+        log.error(`Failed to migrate file from ${oldPath} to ${newPath}:`, error);
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,18 +2,14 @@ import log from "loglevel";
 import { Notice, Plugin } from "obsidian";
 import { OramaNoteChunkRepository } from "./adapter/orama/OramaNoteChunkRepository";
 import { LeafViewCoordinator } from "./application/LeafViewCoordinator";
+import { CodeModeRuntime, type CodeModeStatus } from "./application/CodeModeRuntime";
 import { NoteIndexingService } from "./application/NoteIndexingService";
-import { SettingsService } from "./application/SettingsService";
-import { SimilarNoteCoordinator } from "./application/SimilarNoteCoordinator";
-import type { Command } from "./commands";
 import {
-    ExportActiveNoteSimilarNotesCommand,
-    ReindexAllNotesCommand,
-    RetryErroredNotesCommand,
-    SemanticSearchCommand,
-    ShowSimilarNotesCommand,
-    ToggleInDocumentViewCommand,
-} from "./commands";
+    SettingsService,
+    type EmbeddingModelSettings,
+} from "./application/SettingsService";
+import { SimilarNoteCoordinator } from "./application/SimilarNoteCoordinator";
+import { createPluginCommands, type Command } from "./commands";
 import { SemanticLinkSuggest } from "./components/SemanticLinkSuggest";
 import { SimilarNotesSettingTab } from "./components/SimilarNotesSettingTab";
 import { SimilarNotesSidebarView } from "./components/SimilarNotesSidebarView";
@@ -27,9 +23,15 @@ import type { NoteChunkingService } from "./domain/service/NoteChunkingService";
 import { SimilarNoteFinder } from "./domain/service/SimilarNoteFinder";
 import { TextSearchService } from "./domain/service/TextSearchService";
 import { ErroredNoteStore } from "./infrastructure/ErroredNoteStore";
+import { CodeAwareNoteChunkingService } from "./infrastructure/CodeAwareNoteChunkingService";
+import { FencedCodeBlockExtractor } from "./infrastructure/FencedCodeBlockExtractor";
 import { IndexedNoteMTimeStore } from "./infrastructure/IndexedNoteMTimeStore";
 import { LangchainNoteChunkingService } from "./infrastructure/LangchainNoteChunkingService";
 import { VaultNoteRepository } from "./infrastructure/VaultNoteRepository";
+import {
+    ensurePluginDataDir,
+    migrateDataFile,
+} from "./infrastructure/pluginDataFiles";
 import { needsReindexForUpgrade } from "./lifecycle/versionUpgrade";
 import { NoteChangeQueue } from "./services/noteChangeQueue";
 
@@ -49,6 +51,8 @@ export default class MainPlugin extends Plugin {
     private noteIndexingService: NoteIndexingService;
     private indexedNotesMTimeStore: IndexedNoteMTimeStore;
     private erroredNoteStore: ErroredNoteStore;
+    private readonly fencedCodeBlockExtractor = new FencedCodeBlockExtractor();
+    private codeModeRuntime!: CodeModeRuntime;
     private statusBarView: StatusBarView;
     private settingTab: SimilarNotesSettingTab;
     private commands: Command[] = [];
@@ -93,40 +97,6 @@ export default class MainPlugin extends Plugin {
 
         // Defer all other initialization to onLayoutReady
         this.app.workspace.onLayoutReady(() => this.initializeServices(needsReindex));
-    }
-
-    private async getPluginDataDir(): Promise<string> {
-        const pluginDataDir = `${this.app.vault.configDir}/plugins/${this.manifest.id}`;
-
-        // Ensure the plugin directory exists
-        if (!(await this.app.vault.adapter.exists(pluginDataDir))) {
-            await this.app.vault.adapter.mkdir(pluginDataDir);
-        }
-
-        return pluginDataDir;
-    }
-
-    private async migrateDataFiles(
-        oldPath: string,
-        newPath: string
-    ): Promise<void> {
-        try {
-            if (
-                (await this.app.vault.adapter.exists(oldPath)) &&
-                !(await this.app.vault.adapter.exists(newPath))
-            ) {
-                log.info(`Migrating file from ${oldPath} to ${newPath}`);
-                const data = await this.app.vault.adapter.read(oldPath);
-                await this.app.vault.adapter.write(newPath, data);
-                await this.app.vault.adapter.remove(oldPath);
-                log.info(`Successfully migrated file to plugin folder`);
-            }
-        } catch (error) {
-            log.error(
-                `Failed to migrate file from ${oldPath} to ${newPath}:`,
-                error
-            );
-        }
     }
 
     private registerEvents() {
@@ -175,8 +145,13 @@ export default class MainPlugin extends Plugin {
         await this.erroredNoteStore.init(vaultId);
 
         // Initialize dependent services
-        this.noteChunkingService = new LangchainNoteChunkingService(
+        const markdownChunkingService = new LangchainNoteChunkingService(
             this.modelService
+        );
+        this.noteChunkingService = new CodeAwareNoteChunkingService(
+            markdownChunkingService,
+            this.fencedCodeBlockExtractor,
+            this.settingsService
         );
 
         this.similarNoteFinder = new SimilarNoteFinder(
@@ -196,6 +171,16 @@ export default class MainPlugin extends Plugin {
             this.similarNoteFinder,
             this.settingsService
         );
+        this.codeModeRuntime = new CodeModeRuntime({
+            app: this.app,
+            settingsService: this.settingsService,
+            noteRepository: this.noteRepository,
+            notesModelService: this.modelService,
+            similarNoteCoordinator: this.similarNoteCoordinator,
+            extractor: this.fencedCodeBlockExtractor,
+            rebuildNotesForModeToggle: () =>
+                this.rebuildNotesForCodeModeToggle(),
+        });
 
         this.leafViewCoordinator = new LeafViewCoordinator(
             this.app,
@@ -237,7 +222,7 @@ export default class MainPlugin extends Plugin {
             noteChunkRepository: this.noteChunkRepository,
             modelService: this.modelService,
             onRetry: () => {
-                this.init(this.settingsService.get().modelId, true, false);
+                void this.retryErroredNotes();
             },
             onOpenSettings: () => {
                 // @ts-expect-error - Obsidian's setting API
@@ -253,7 +238,10 @@ export default class MainPlugin extends Plugin {
             (leaf) =>
                 new SimilarNotesSidebarView(
                     leaf,
-                    this.similarNoteCoordinator.getNoteBottomViewModelObservable()
+                    this.similarNoteCoordinator.getNoteBottomViewModelObservable(),
+                    (mode) => {
+                        void this.similarNoteCoordinator.setSearchMode(mode);
+                    }
                 )
         );
         this.sidebarViewRegistered = true;
@@ -265,7 +253,10 @@ export default class MainPlugin extends Plugin {
         this.registerEditorSuggest(
             new SemanticLinkSuggest(
                 this.app,
-                this.textSearchService,
+                this.similarNoteCoordinator.coordinateTextSearch(
+                    "notes",
+                    this.textSearchService
+                ),
                 this.settingsService
             )
         );
@@ -276,24 +267,25 @@ export default class MainPlugin extends Plugin {
         // Complete initialization
         // If needsReindex is true, trigger a reindex to migrate from JSON to IndexedDB
         await this.init(this.settingsService.get().modelId, true, needsReindex);
+        if (this.settingsService.get().codeModeEnabled) {
+            await this.codeModeRuntime.initialize(!needsReindex);
+        }
     }
 
     private registerCommands() {
-        // Initialize commands
-        this.commands = [
-            new ShowSimilarNotesCommand(this),
-            new ToggleInDocumentViewCommand(this.settingsService),
-            new ReindexAllNotesCommand(this),
-            new RetryErroredNotesCommand(this),
-            new SemanticSearchCommand(
-                this.app,
-                this.textSearchService,
-                this.settingsService
+        this.commands = createPluginCommands({
+            plugin: this,
+            app: this.app,
+            settingsService: this.settingsService,
+            similarNoteCoordinator: this.similarNoteCoordinator,
+            notesTextSearch: this.similarNoteCoordinator.coordinateTextSearch(
+                "notes",
+                this.textSearchService
             ),
-            new ExportActiveNoteSimilarNotesCommand(this.app, this.similarNoteCoordinator, this.manifest.id),
-        ];
+            getCodeTextSearch: () => this.codeModeRuntime.getSearchService(),
+            manifestId: this.manifest.id,
+        });
 
-        // Register each command
         this.commands.forEach((command) => {
             command.register(this);
         });
@@ -332,23 +324,26 @@ export default class MainPlugin extends Plugin {
         this.app.workspace.detachLeavesOfType(VIEW_TYPE_SIMILAR_NOTES_SIDEBAR);
 
         this.statusBarView.dispose();
-        this.noteIndexingService.stopLoop();
-        this.leafViewCoordinator.onUnload();
+        await this.similarNoteCoordinator.closeSearchMode(
+            "notes",
+            async () => {
+                this.noteIndexingService.stopLoop();
+                await this.noteIndexingService.waitUntilIdle();
+                this.leafViewCoordinator.onUnload();
+                await this.codeModeRuntime?.dispose(false);
 
-        // Explicitly dispose Orama worker
-        if (this.noteChunkRepository) {
-            // Call our new dispose method on the repository
-            log.info("Disposing note chunk repository worker");
-            await this.noteChunkRepository.dispose();
-        }
+                if (this.noteChunkRepository) {
+                    log.info("Disposing note chunk repository worker");
+                    await this.noteChunkRepository.dispose();
+                }
 
-        this.noteChangeQueue.cleanup();
-
-        // Dispose of model service - do this last as it's the most memory intensive
-        if (this.modelService) {
-            log.info("Disposing model service");
-            this.modelService.dispose();
-        }
+                this.noteChangeQueue.cleanup();
+                if (this.modelService) {
+                    log.info("Disposing model service");
+                    await this.modelService.disposeWhenIdle();
+                }
+            }
+        );
 
         log.info("Similar Notes plugin unloaded");
     }
@@ -364,14 +359,19 @@ export default class MainPlugin extends Plugin {
         if (this.noteChunkRepository?.setLogLevel) {
             this.noteChunkRepository.setLogLevel(level);
         }
+        this.codeModeRuntime?.setLogLevel(level);
     }
 
-    async init(
-        modelId: string,
-        firstTime: boolean,
-        newModel: boolean
-    ): Promise<void> {
+    async init(modelId: string, firstTime: boolean, newModel: boolean): Promise<void> {
+        await this.similarNoteCoordinator.runSearchTransition(
+            "notes",
+            async () => this.initUnlocked(modelId, firstTime, newModel)
+        );
+    }
+
+    private async initUnlocked(modelId: string, firstTime: boolean, newModel: boolean): Promise<void> {
         this.noteIndexingService.stopLoop();
+        await this.noteIndexingService.waitUntilIdle();
 
         try {
             if (firstTime || newModel) {
@@ -379,7 +379,7 @@ export default class MainPlugin extends Plugin {
                 const settings = this.settingsService.get();
 
                 // Switch to appropriate provider based on settings
-                await this.modelService.switchProvider(settings);
+                await this.codeModeRuntime.switchNotesModel(settings);
                 log.info(
                     "Model service initialized successfully with provider:",
                     settings.modelProvider,
@@ -389,15 +389,21 @@ export default class MainPlugin extends Plugin {
                         : settings.ollamaModel
                 );
 
-                this.noteChunkingService.init();
+                await this.noteChunkingService.init();
             }
         } catch (error) {
             log.error("Failed to initialize model service:", error);
-            return;
+            if (!firstTime) {
+                this.noteIndexingService.startLoop();
+            }
+            throw error;
         }
 
         const vectorSize = this.modelService.getVectorSize();
-        const pluginDataDir = await this.getPluginDataDir();
+        const pluginDataDir = await ensurePluginDataDir(
+            this.app.vault,
+            this.manifest.id
+        );
         const dbPath = `${pluginDataDir}/${dbFileName}`;
 
         // Get vault ID for IndexedDB isolation
@@ -406,7 +412,7 @@ export default class MainPlugin extends Plugin {
 
         // Migrate existing database from old location to new location
         const oldDbPath = `${this.app.vault.configDir}/${dbFileName}`;
-        await this.migrateDataFiles(oldDbPath, dbPath);
+        await migrateDataFile(this.app.vault, oldDbPath, dbPath);
 
         if (firstTime) {
             await this.noteChunkRepository.init(
@@ -420,7 +426,7 @@ export default class MainPlugin extends Plugin {
                 vaultId,
                 false // loadExistingData - reindex from scratch
             );
-            this.noteChangeQueue.enqueueAllNotes();
+            await this.noteChangeQueue.enqueueAllNotes();
         }
 
         // Pass NoteChunkRepository to the settings tab after it's initialized
@@ -432,7 +438,10 @@ export default class MainPlugin extends Plugin {
 
     // Re-queue all terminally-errored notes for another attempt
     async retryErroredNotes(): Promise<void> {
-        await this.noteChangeQueue.retryErrored();
+        await Promise.all([
+            this.noteChangeQueue.retryErrored(),
+            this.codeModeRuntime?.retryErrored() ?? Promise.resolve(),
+        ]);
     }
 
     // Handle reindexing of notes
@@ -441,14 +450,16 @@ export default class MainPlugin extends Plugin {
         await this.indexedNotesMTimeStore.clear();
         await this.erroredNoteStore.clear();
         await this.init(this.settingsService.get().modelId, false, false);
+        if (this.settingsService.get().codeModeEnabled) {
+            await this.codeModeRuntime?.reindex();
+        }
     }
 
     // Apply current exclusion patterns to synchronize index with current patterns
-    async applyExclusionPatterns(): Promise<{
-        removed: number;
-        added: number;
-    }> {
-        return await this.noteChangeQueue.applyExclusionPatterns();
+    async applyExclusionPatterns(): Promise<{ removed: number; added: number }> {
+        const notesResult = await this.noteChangeQueue.applyExclusionPatterns();
+        await this.codeModeRuntime?.applyExclusionPatterns();
+        return notesResult;
     }
 
     // Preview how many files would be changed by current patterns
@@ -472,13 +483,14 @@ export default class MainPlugin extends Plugin {
     async reloadModel(): Promise<void> {
         // Stop the indexing service to prevent any operations during model reload
         this.noteIndexingService.stopLoop();
+        await this.noteIndexingService.waitUntilIdle();
 
         // Get current settings
         const settings = this.settingsService.get();
 
         try {
             // Reload the model with current settings
-            await this.modelService.switchProvider(settings);
+            await this.codeModeRuntime.switchNotesModel(settings);
         } catch (error) {
             log.error("Failed to reload model:", error);
             // Error state is handled by modelError$ observable in StatusBarView
@@ -487,5 +499,27 @@ export default class MainPlugin extends Plugin {
             // This ensures the service doesn't remain stopped
             this.noteIndexingService.startLoop();
         }
+    }
+
+    async applyCodeModeChanges(enabled: boolean, codeModel: EmbeddingModelSettings): Promise<void> {
+        if (!this.codeModeRuntime) {
+            throw new Error("Similar Notes is still loading");
+        }
+        await this.codeModeRuntime.applyChanges(enabled, codeModel);
+    }
+
+    async getCodeModeStatus(): Promise<CodeModeStatus> {
+        if (!this.codeModeRuntime) {
+            return { indexedNotes: 0, chunks: 0, erroredNotes: 0 };
+        }
+        return await this.codeModeRuntime.getStatus();
+    }
+
+    private async rebuildNotesForCodeModeToggle(): Promise<void> {
+        await Promise.all([
+            this.indexedNotesMTimeStore.clear(),
+            this.erroredNoteStore.clear(),
+        ]);
+        await this.initUnlocked(this.settingsService.get().modelId, false, false);
     }
 }

--- a/src/utils/AsyncOperationGate.ts
+++ b/src/utils/AsyncOperationGate.ts
@@ -1,0 +1,65 @@
+/**
+ * Coordinates ordinary async operations with exclusive lifecycle transitions.
+ * Operations admitted before a transition are drained; later operations wait
+ * until the transition completes.
+ */
+export class AsyncOperationGate {
+    private readonly activeOperations = new Set<Promise<unknown>>();
+    private transitionTail: Promise<void> = Promise.resolve();
+    private closedError?: Error;
+
+    async run<T>(operation: () => Promise<T>): Promise<T> {
+        if (this.closedError) throw this.closedError;
+        const admissionBarrier = this.transitionTail;
+        await admissionBarrier;
+        if (this.closedError) throw this.closedError;
+
+        const result = Promise.resolve().then(operation);
+        this.activeOperations.add(result);
+        void result.then(
+            () => this.activeOperations.delete(result),
+            () => this.activeOperations.delete(result)
+        );
+        return await result;
+    }
+
+    async transition<T>(operation: () => Promise<T>): Promise<T> {
+        if (this.closedError) throw this.closedError;
+        return await this.enqueueTransition(operation);
+    }
+
+    async close<T>(
+        operation: () => Promise<T>,
+        error = new Error("Async operation gate is closed")
+    ): Promise<T> {
+        if (this.closedError) throw this.closedError;
+        this.closedError = error;
+        return await this.enqueueTransition(operation);
+    }
+
+    private async enqueueTransition<T>(
+        operation: () => Promise<T>
+    ): Promise<T> {
+        const previousTransition = this.transitionTail;
+        const result = previousTransition.then(async () => {
+            await this.waitForActiveOperations();
+            return await operation();
+        });
+        this.transitionTail = result.then(
+            () => undefined,
+            () => undefined
+        );
+        return await result;
+    }
+
+    async waitUntilIdle(): Promise<void> {
+        await this.transitionTail;
+        await this.waitForActiveOperations();
+    }
+
+    private async waitForActiveOperations(): Promise<void> {
+        while (this.activeOperations.size > 0) {
+            await Promise.allSettled([...this.activeOperations]);
+        }
+    }
+}

--- a/src/utils/__tests__/AsyncOperationGate.test.ts
+++ b/src/utils/__tests__/AsyncOperationGate.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import { AsyncOperationGate } from "../AsyncOperationGate";
+
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((resolvePromise) => {
+        resolve = resolvePromise;
+    });
+    return { promise, resolve };
+}
+
+describe("AsyncOperationGate", () => {
+    it("drains admitted work and blocks later work during a transition", async () => {
+        const gate = new AsyncOperationGate();
+        const first = deferred<void>();
+        const lifecycle = deferred<void>();
+        const events: string[] = [];
+
+        const active = gate.run(async () => {
+            events.push("active-start");
+            await first.promise;
+            events.push("active-end");
+        });
+        const transition = gate.transition(async () => {
+            events.push("transition-start");
+            await lifecycle.promise;
+            events.push("transition-end");
+        });
+        const laterOperation = vi.fn(async () => {
+            events.push("later");
+        });
+        const later = gate.run(laterOperation);
+
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(events).toEqual(["active-start"]);
+        first.resolve();
+        await active;
+        await vi.waitFor(() =>
+            expect(events).toEqual([
+                "active-start",
+                "active-end",
+                "transition-start",
+            ])
+        );
+        expect(laterOperation).not.toHaveBeenCalled();
+
+        lifecycle.resolve();
+        await Promise.all([transition, later]);
+        expect(events).toEqual([
+            "active-start",
+            "active-end",
+            "transition-start",
+            "transition-end",
+            "later",
+        ]);
+    });
+
+    it("releases queued operations when a transition fails", async () => {
+        const gate = new AsyncOperationGate();
+        const transition = gate.transition(async () => {
+            throw new Error("failed");
+        });
+        const operation = gate.run(async () => "ready");
+
+        await expect(transition).rejects.toThrow("failed");
+        await expect(operation).resolves.toBe("ready");
+    });
+
+    it("permanently rejects operations admitted after close begins", async () => {
+        const gate = new AsyncOperationGate();
+        const active = deferred<void>();
+        const running = gate.run(async () => active.promise);
+        await Promise.resolve();
+        await Promise.resolve();
+        const closing = gate.close(async () => undefined);
+        const late = gate.run(async () => "too late");
+        const lateExpectation = expect(late).rejects.toThrow("closed");
+
+        active.resolve();
+        await running;
+        await closing;
+        await lateExpectation;
+        await expect(gate.run(async () => "later")).rejects.toThrow("closed");
+    });
+});

--- a/src/utils/__tests__/environmentInfo.test.ts
+++ b/src/utils/__tests__/environmentInfo.test.ts
@@ -16,6 +16,13 @@ function makeInfo(system: SystemInfo): EnvironmentInfo {
         modelId: "Built-in (sentence-transformers/all-MiniLM-L6-v2)",
         serverUrl: null,
         webGPU: false,
+        codeMode: {
+            enabled: false,
+            modelProvider: null,
+            modelId: null,
+            serverUrl: null,
+            webGPU: null,
+        },
         system,
         chunkSettings: {
             includeFrontmatter: false,
@@ -135,5 +142,33 @@ describe("formatEnvironmentInfoAsMarkdown: server URL line", () => {
             makeInfo({ totalMemoryGB: null, cpuCores: null, arch: null })
         );
         expect(md).not.toContain("**Server URL**");
+    });
+});
+
+describe("Code Mode diagnostics", () => {
+    test("reports the Code profile without exposing its API key", () => {
+        const info = collectEnvironmentInfo(
+            "1.12.7",
+            "1.6.0",
+            makeSettings({
+                codeModeEnabled: true,
+                codeModel: {
+                    modelProvider: "openai",
+                    modelId: "unused",
+                    openaiUrl: "https://code.example/v1",
+                    openaiApiKey: "must-not-leak",
+                    openaiModel: "code-embed",
+                    useGPU: false,
+                },
+            })
+        );
+        const markdown = formatEnvironmentInfoAsMarkdown(info);
+
+        expect(markdown).toContain("- **Code Mode**: Enabled");
+        expect(markdown).toContain("- **Code Model**: OpenAI (code-embed)");
+        expect(markdown).toContain(
+            "- **Code Server URL**: https://code.example/v1"
+        );
+        expect(markdown).not.toContain("must-not-leak");
     });
 });

--- a/src/utils/environmentInfo.ts
+++ b/src/utils/environmentInfo.ts
@@ -1,5 +1,8 @@
 import { Platform } from "obsidian";
-import type { SimilarNotesSettings } from "@/application/SettingsService";
+import type {
+    EmbeddingModelSettings,
+    SimilarNotesSettings,
+} from "@/application/SettingsService";
 
 export interface SystemInfo {
     totalMemoryGB: number | null;
@@ -15,6 +18,13 @@ export interface EnvironmentInfo {
     modelId: string;
     serverUrl: string | null;
     webGPU: boolean;
+    codeMode: {
+        enabled: boolean;
+        modelProvider: string | null;
+        modelId: string | null;
+        serverUrl: string | null;
+        webGPU: boolean | null;
+    };
     system: SystemInfo;
     chunkSettings: {
         includeFrontmatter: boolean;
@@ -80,7 +90,7 @@ function getPlatformString(): string {
     return "Unknown";
 }
 
-function getModelDisplayName(settings: SimilarNotesSettings): string {
+function getModelDisplayName(settings: EmbeddingModelSettings): string {
     switch (settings.modelProvider) {
         case "ollama":
             return `Ollama (${settings.ollamaModel || "not configured"})`;
@@ -98,7 +108,7 @@ function getModelDisplayName(settings: SimilarNotesSettings): string {
  * OpenAI vs OpenRouter vs a local server; local vs remote Ollama). Null for
  * providers with a fixed endpoint.
  */
-function getServerUrl(settings: SimilarNotesSettings): string | null {
+function getServerUrl(settings: EmbeddingModelSettings): string | null {
     switch (settings.modelProvider) {
         case "ollama":
             return settings.ollamaUrl || "http://localhost:11434";
@@ -114,6 +124,7 @@ export function collectEnvironmentInfo(
     pluginVersion: string,
     settings: SimilarNotesSettings
 ): EnvironmentInfo {
+    const codeModel = settings.codeModel ?? settings;
     return {
         platform: getPlatformString(),
         obsidianVersion,
@@ -122,6 +133,19 @@ export function collectEnvironmentInfo(
         modelId: getModelDisplayName(settings),
         serverUrl: getServerUrl(settings),
         webGPU: settings.useGPU,
+        codeMode: {
+            enabled: settings.codeModeEnabled,
+            modelProvider: settings.codeModeEnabled
+                ? codeModel.modelProvider
+                : null,
+            modelId: settings.codeModeEnabled
+                ? getModelDisplayName(codeModel)
+                : null,
+            serverUrl: settings.codeModeEnabled
+                ? getServerUrl(codeModel)
+                : null,
+            webGPU: settings.codeModeEnabled ? codeModel.useGPU : null,
+        },
         system: collectSystemInfo(),
         chunkSettings: {
             includeFrontmatter: settings.includeFrontmatter,
@@ -153,6 +177,21 @@ export function formatEnvironmentInfoAsMarkdown(info: EnvironmentInfo): string {
 
     if (info.serverUrl !== null) {
         lines.push(`- **Server URL**: ${info.serverUrl}`);
+    }
+
+    lines.push(
+        `- **Code Mode**: ${info.codeMode.enabled ? "Enabled" : "Disabled"}`
+    );
+    if (info.codeMode.enabled && info.codeMode.modelId) {
+        lines.push(`- **Code Model**: ${info.codeMode.modelId}`);
+        if (info.codeMode.serverUrl) {
+            lines.push(`- **Code Server URL**: ${info.codeMode.serverUrl}`);
+        }
+        lines.push(
+            `- **Code WebGPU**: ${
+                info.codeMode.webGPU ? "Enabled" : "Disabled"
+            }`
+        );
     }
 
     lines.push(

--- a/styles.css
+++ b/styles.css
@@ -399,13 +399,15 @@ select option:disabled {
 
 /* Settings section wrappers - match Obsidian's setting-group margin (24px) for proper spacing */
 .usage-stats-section:not(:first-child),
-.index-settings-section:not(:first-child) {
+.index-settings-section:not(:first-child),
+.code-model-settings-section:not(:first-child) {
     margin-top: var(--size-4-6);
 }
 
 /* SettingGroup after wrapper divs needs margin since wrapper has no margin */
 .index-settings-section + .setting-group,
-.model-settings-section + .setting-group {
+.model-settings-section + .setting-group,
+.code-model-settings-section + .setting-group {
     margin-top: var(--size-4-6);
 }
 
@@ -434,4 +436,40 @@ select option:disabled {
 
 .similar-notes-mobile-warning .setting-item-name {
     color: var(--text-warning);
+}
+
+/* Explicit index selector. Scores from Notes and Code models are intentionally
+   kept in separate result sets rather than blended across embedding spaces. */
+.similar-notes-mode-switcher,
+.semantic-search-mode-switcher {
+    display: flex;
+    gap: var(--size-4-1);
+    padding: var(--size-4-2);
+}
+
+.semantic-search-mode-switcher {
+    border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.similar-notes-mode-switcher button,
+.semantic-search-mode-switcher button {
+    flex: 1;
+    min-height: 28px;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-s);
+    background: var(--background-secondary);
+    color: var(--text-muted);
+}
+
+.similar-notes-mode-switcher button:hover,
+.semantic-search-mode-switcher button:hover {
+    background: var(--background-modifier-hover);
+    color: var(--text-normal);
+}
+
+.similar-notes-mode-switcher button.is-active,
+.semantic-search-mode-switcher button.is-active {
+    border-color: var(--interactive-accent);
+    background: var(--interactive-accent);
+    color: var(--text-on-accent);
 }


### PR DESCRIPTION
## Summary

Add an optional Code Mode that keeps prose in the existing Notes index and
embeds fenced code blocks in a separate Code index with its own model. Results
remain mode-specific; scores from different embedding spaces are never mixed.
Code Mode is off by default, so existing Notes behavior is unchanged.

- Extract backtick and tilde fences with language and line metadata.
- Support independent Code embedding models through local Hugging
  Face/Transformers models with ONNX weights, Ollama, OpenAI-compatible APIs,
  and Google Gemini. Recommended built-ins are `all-MiniLM-L6-v2` and
  `paraphrase-multilingual-MiniLM-L12-v2`; no code-specialized model is bundled.
- Give Code its own namespaced persistence, status, queues, fingerprints, and
  rebuild lifecycle.
- Add Notes/Code switching to the sidebar, bottom view, and Semantic Search.
- Make model and index changes transactional, with rollback and lifecycle gates
  that prevent stale work from publishing results.
- Document persistence, resource use, mobile constraints, and remote-provider
  privacy implications.

No new runtime dependencies, IndexedDB schema-version bump, release-version
bump, or changes to existing Notes persistence names.

Closes #52.

## Test plan

- [x] `npm run test` — 36 files, 240 tests
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`

Automated coverage includes extraction and chunking, Notes/Code partitioning,
persistence and migration, mode-specific routing and caches, transactional
rollback, stale-result suppression, teardown, and unload behavior.

### Manual Obsidian verification

Verified with disposable vaults on Obsidian 1.12.7 and 1.13.1. Build artifacts
were copied manually because `install-local` delegates to a gitignored,
developer-local helper that is not shipped with the repository.

- [x] Confirm disabled mode preserves whole-note Notes indexing and exposes no
  Notes/Code selectors.
- [x] Enable Code Mode and verify separate prose/code results in the sidebar,
  bottom view, and Semantic Search persist after restart.
- [x] Verify fence removal, rename, deletion, and folder exclusion update both
  indexes without stale results.
- [x] Rebuild with a different Code model and verify invalid-model rollback
  restores the previous usable model and index.
- [x] Disable and remove the Code index; confirm status becomes `Disabled`,
  selectors disappear, and Notes search again retrieves fenced-code content.

See `docs/code-mode-spec.md` for the detailed behavior contract.
