### PR TITLE
perf: skip unchanged indexable-text embeddings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Improved
+
+-   **Unchanged indexable notes no longer regenerate embeddings** (#51): Writes that only change excluded frontmatter or regex-filtered content now advance indexing state without rerunning local or API embeddings, reducing unnecessary CPU use and provider calls.
+
 ## [1.6.0] - 2026-07-03
 
 ### Added

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,11 +67,13 @@ src/
 
 6. **Built-in embedding per-pass batch cap**: The built-in (Transformers.js / onnxruntime-web) embedder caps chunks per forward pass at `MAX_EMBED_BATCH_SIZE` (32) and runs sub-batches sequentially (`transformers.worker.ts`, `splitIntoBatches`/`embedInBatches` in `src/utils/batching.ts`). Embedding a large note's chunks in one pass overran the wasm32 ~4GB address space and aborted with a bare number (and then cascaded). Note: this is *not* a threading issue — the beta.4 single-thread pin was a no-op. See `docs/builtin-embedding-batch-cap-spec.md`.
 
-5. **Settings Storage**: Plugin settings are stored in Obsidian's data.json. UI for settings uses React components.
+7. **Indexable-text hash gate**: File mtimes select notes that may need indexing. Queued notes hash their effective text after frontmatter and regex exclusions; unchanged hashes skip chunking and embedding while still advancing the stored mtime. See `docs/indexable-text-hash-spec.md`.
+
+8. **Settings Storage**: Plugin settings are stored in Obsidian's data.json. UI for settings uses React components.
 
    - **Sectioning**: The settings tab is divided into top-level sections using Obsidian's `SettingGroup` (`@since 1.11.0`) — one per area (e.g. Model, Index, Exclude folders from index, Exclude content from index, Display, Debug & Support). Each section is built by a `*SettingsSection` class (e.g. `IndexSettingsSection`) that returns `SettingBuilder` arrays.
    - **Use sibling groups, not sub-headings.** `SettingGroup` cannot nest, and inserting `Setting.setHeading()` divider rows *inside* a group renders poorly (tried more than once and reverted). To break a crowded section into sub-areas, add another sibling top-level `SettingGroup` instead of nesting or in-group headings.
 
-5. **Content Exclusion**: Supports RegExp patterns to exclude content from indexing (e.g., frontmatter, code blocks).
+9. **Content Exclusion**: Supports RegExp patterns to exclude content from indexing (e.g., frontmatter, code blocks).
 
-6. **Command Palette**: Commands are implemented in `src/commands/` with a extensible structure for easy addition of new commands.
+10. **Command Palette**: Commands are implemented in `src/commands/` with a extensible structure for easy addition of new commands.

--- a/docs/indexable-text-hash-spec.md
+++ b/docs/indexable-text-hash-spec.md
@@ -1,0 +1,78 @@
+# Indexable Text Hash Specification
+
+## Status
+
+Accepted for [issue #51](https://github.com/joybro/obsidian-similar-notes/issues/51).
+
+## Problem
+
+File modification time is a cheap way to find notes that may need indexing, but
+it does not prove that their embedding input changed. For example, another
+plugin can update only frontmatter while **Include frontmatter** is disabled, or
+it can update text removed by a configured content-exclusion pattern. Repeating
+chunking and embedding for those writes wastes local CPU or paid API calls.
+
+## Decision
+
+Indexing uses two checks:
+
+1. Modification time selects candidate notes for the existing change queue.
+2. A versioned hash of effective indexable text decides whether a queued note
+   needs new chunks and embeddings.
+
+The plugin never hashes every note during startup. Only a note already selected
+by the mtime/event queue pays the hashing cost.
+
+## Canonical Hash Input
+
+The input is the exact content string produced by the existing indexing
+preprocessing pipeline:
+
+1. Read the note with or without frontmatter according to the current setting.
+2. Apply configured exclusion regexes in order with their existing `gm` flags.
+3. Hash the resulting string before chunking.
+
+No trimming, whitespace folding, Unicode normalization, or newline conversion
+is added. Those transformations could hide changes that affect chunk boundaries
+or embedding input. Path, title, and mtime are excluded: title follows path, and
+the existing pure-rename contract deliberately carries embeddings without
+regenerating them.
+
+Hash format is `v1:<sha256-hex>`, calculated with Web Crypto. The prefix lets a
+future preprocessing-contract change invalidate old hashes without changing the
+IndexedDB schema.
+
+## Processing Rules
+
+- Stored hash exists, matches, and change is not forced: skip splitting,
+  embedding, chunk replacement, and semantic-result recomputation. Persist the
+  newer mtime with the unchanged hash. If the note is active, refresh cached
+  link/display metadata without repeating vector search.
+- Stored hash is missing or different: run the existing split/embed/replace
+  flow. Persist the new mtime and hash only after chunk persistence succeeds.
+- Effective content is empty, or splitting produces no chunks: remove any stale
+  chunks, perform no embedding, and persist the empty-content hash.
+- Explicit full reindex and errored-note retry are forced changes. They do not
+  short-circuit on a matching hash.
+
+## Persistence and Compatibility
+
+The existing per-note mtime IndexedDB record gains an optional
+`indexableTextHash` field. IndexedDB object records are schemaless, so the
+current database version and `path` key remain unchanged.
+
+Legacy `{ path, mtime }` records load with an unknown hash. They are not scanned
+or migrated in bulk; the next queued modification embeds once and backfills the
+hash. Full reindex and model-change flows already clear the metadata store, so
+they also clear hashes. Pure renames move the hash with the mtime and preserved
+chunks. Deletes remove both.
+
+## Failure and Concurrency Rules
+
+Hashing, embedding, or chunk-repository failures must not advance processed
+metadata. Existing retry and terminal-error handling remains responsible for
+those failures. A metadata-write failure happens after chunk persistence and is
+retried without claiming durable completion.
+
+Existing cross-note parallelism remains unchanged. Queue debouncing normally
+prevents same-path overlap; adding a per-path lock is outside this change.

--- a/src/application/NoteIndexingService.ts
+++ b/src/application/NoteIndexingService.ts
@@ -6,6 +6,7 @@ import type { NoteChunkingService } from "@/domain/service/NoteChunkingService";
 import type { ErroredNoteStore } from "@/infrastructure/ErroredNoteStore";
 import type { NoteChange, NoteChangeQueue } from "@/services/noteChangeQueue";
 import { showNoteErrorNotice } from "@/utils/errorHandling";
+import { computeIndexableTextHash } from "@/utils/indexableTextHash";
 import log from "loglevel";
 import type { App } from "obsidian";
 import { type Observable, BehaviorSubject } from "rxjs";
@@ -66,16 +67,24 @@ export class NoteIndexingService {
         log.info(`[NoteIndexingService] ===== Processing change: ${change.path} (${change.reason}) =====`);
 
         try {
+            let indexableTextHash: string | undefined;
+
             if (change.reason === "deleted") {
                 await this.processDeletedNote(change.path);
             } else if (change.reason === "renamed") {
-                await this.processRenamedNote(change);
+                indexableTextHash = await this.processRenamedNote(change);
             } else {
-                await this.processUpdatedNote(change.path);
+                indexableTextHash = await this.processUpdatedNote(
+                    change.path,
+                    change.forceReindex
+                );
             }
 
             // Success: mark processed and clear any prior errored entry.
-            await this.noteChangeQueue.markNoteChangeProcessed(change);
+            await this.noteChangeQueue.markNoteChangeProcessed(
+                change,
+                indexableTextHash
+            );
             if (this.erroredNoteStore.get(change.path)) {
                 await this.erroredNoteStore.delete(change.path);
             }
@@ -137,7 +146,9 @@ export class NoteIndexingService {
         await this.noteChunkRepository.removeByPath(path);
     }
 
-    private async processRenamedNote(change: NoteChange) {
+    private async processRenamedNote(
+        change: NoteChange
+    ): Promise<string | undefined> {
         const { oldPath, path: newPath } = change;
         if (!oldPath) {
             // Defensive: a "renamed" change without oldPath is malformed.
@@ -145,8 +156,7 @@ export class NoteIndexingService {
             log.warn(
                 `[NoteIndexingService] Renamed change missing oldPath, falling back to full embed: ${newPath}`
             );
-            await this.processUpdatedNote(newPath);
-            return;
+            return this.processUpdatedNote(newPath, change.forceReindex);
         }
 
         const carried = await this.noteChunkRepository.renamePath(
@@ -159,8 +169,7 @@ export class NoteIndexingService {
             log.info(
                 `[NoteIndexingService] No prior chunks for ${oldPath}, embedding ${newPath} fresh`
             );
-            await this.processUpdatedNote(newPath);
-            return;
+            return this.processUpdatedNote(newPath, change.forceReindex);
         }
 
         log.info(
@@ -168,20 +177,20 @@ export class NoteIndexingService {
         );
 
         // If the renamed file is the currently active one, refresh the sidebar.
-        const activeFile = this.app.workspace.getActiveFile();
-        if (activeFile && activeFile.path === newPath) {
-            this.similarNoteCoordinator.emitNoteBottomViewModelFromPath(
-                newPath
-            );
-        }
+        this.refreshActiveNote(newPath);
+
+        return undefined;
     }
 
-    private async processUpdatedNote(path: string) {
+    private async processUpdatedNote(
+        path: string,
+        forceReindex = false
+    ): Promise<string | undefined> {
         const note = await this.noteRepository.findByPath(
             path,
             !this.settingsService.get().includeFrontmatter
         );
-        if (!note || !note.content) {
+        if (!note) {
             return;
         }
 
@@ -189,12 +198,9 @@ export class NoteIndexingService {
         const settings = this.settingsService.get();
         const patterns = settings.excludeRegexPatterns || [];
 
-        // Create a copy of the note with filtered content
-        const filteredNote = { ...note };
-
         // Apply each regex pattern to exclude matching content
+        let filteredContent = note.content ?? "";
         if (patterns.length > 0) {
-            let filteredContent = note.content;
             for (const pattern of patterns) {
                 try {
                     const regex = new RegExp(pattern, "gm");
@@ -203,12 +209,35 @@ export class NoteIndexingService {
                     log.warn(`Invalid RegExp pattern: ${pattern}`, e);
                 }
             }
-            filteredNote.content = filteredContent;
+        }
+
+        const indexableTextHash = await computeIndexableTextHash(
+            filteredContent
+        );
+        const storedHash = await this.noteChangeQueue.getIndexableTextHash(
+            path
+        );
+
+        if (!forceReindex && storedHash === indexableTextHash) {
+            log.info(
+                `[NoteIndexingService] Indexable text unchanged for ${path}, skipping re-embedding`
+            );
+            this.refreshActiveNoteMetadata(path);
+            return indexableTextHash;
+        }
+
+        // Create a copy of the note with exactly the content used for hashing.
+        const filteredNote = { ...note, content: filteredContent };
+
+        if (!filteredContent) {
+            await this.removeIndexedChunksAndRefreshActiveNote(note.path);
+            return indexableTextHash;
         }
 
         const splitted = await this.noteChunkingService.split(filteredNote);
         if (splitted.length === 0) {
-            return;
+            await this.removeIndexedChunksAndRefreshActiveNote(note.path);
+            return indexableTextHash;
         }
 
         log.info(`[NoteIndexingService] Generating embeddings for ${splitted.length} chunks (for indexing)`);
@@ -246,11 +275,44 @@ export class NoteIndexingService {
         const activeFile = this.app.workspace.getActiveFile();
         if (activeFile && activeFile.path === note.path) {
             log.info(`[NoteIndexingService] File is currently active, triggering similar note search`);
-            this.similarNoteCoordinator.emitNoteBottomViewModelFromPath(
-                note.path
-            );
+            this.refreshActiveNote(note.path);
         } else {
             log.info(`[NoteIndexingService] File is not currently active, skipping similar note search`);
         }
+
+        return indexableTextHash;
+    }
+
+    private async removeIndexedChunksAndRefreshActiveNote(
+        path: string
+    ): Promise<void> {
+        await this.noteChunkRepository.removeByPath(path);
+
+        this.refreshActiveNote(path);
+    }
+
+    private refreshActiveNote(path: string): void {
+        const activeFile = this.app.workspace.getActiveFile();
+        if (!activeFile || activeFile.path !== path) {
+            return;
+        }
+
+        void this.similarNoteCoordinator.emitNoteBottomViewModelFromPath(path);
+    }
+
+    private refreshActiveNoteMetadata(path: string): void {
+        const activeFile = this.app.workspace.getActiveFile();
+        if (!activeFile || activeFile.path !== path) {
+            return;
+        }
+
+        void this.similarNoteCoordinator
+            .refreshCachedNoteMetadataFromPath(path)
+            .catch((error) =>
+                log.warn(
+                    `[NoteIndexingService] Failed to refresh cached metadata for ${path}`,
+                    error
+                )
+            );
     }
 }

--- a/src/application/SimilarNoteCoordinator.ts
+++ b/src/application/SimilarNoteCoordinator.ts
@@ -108,6 +108,71 @@ export class SimilarNoteCoordinator {
         await this.emitNoteBottomViewModel(file);
     }
 
+    /**
+     * Refresh metadata derived from the active note without repeating vector
+     * search. Used when indexing proves the effective embedding text is
+     * unchanged but excluded content may have changed links.
+     */
+    async refreshCachedNoteMetadataFromPath(path: string): Promise<boolean> {
+        const file = this.vault.getFileByPath(path);
+        if (!file) {
+            return false;
+        }
+
+        const settings = this.settingsService.get();
+        const cacheKey = file.path;
+        const currentView = this.noteBottomViewModel$.value;
+        if (
+            !this.cache.has(cacheKey) &&
+            currentView.currentFile?.path !== file.path
+        ) {
+            return false;
+        }
+
+        const note = await this.noteRepository.findByFile(
+            file,
+            !settings.includeFrontmatter
+        );
+        const linkedPaths = new Set(note.links);
+        const updateLinks = (entries: SimilarNoteEntry[]) =>
+            entries.map((entry) => ({
+                ...entry,
+                isLinked: linkedPaths.has(entry.file.path),
+            }));
+
+        const cached = this.cache.get(cacheKey);
+        if (cached) {
+            const updatedNotes = updateLinks(cached.notes);
+            this.cache.set(cacheKey, {
+                mtime: file.stat.mtime,
+                notes: updatedNotes,
+            });
+
+            const latestView = this.noteBottomViewModel$.value;
+            if (latestView.currentFile?.path === file.path) {
+                const threshold = this.settingsService.get()
+                    .minSimilarityThreshold;
+                this.noteBottomViewModel$.next({
+                    ...latestView,
+                    similarNoteEntries: updatedNotes.filter(
+                        (entry) => entry.similarity >= threshold
+                    ),
+                });
+            }
+            return true;
+        }
+
+        const latestView = this.noteBottomViewModel$.value;
+        if (latestView.currentFile?.path !== file.path) {
+            return false;
+        }
+        this.noteBottomViewModel$.next({
+            ...latestView,
+            similarNoteEntries: updateLinks(latestView.similarNoteEntries),
+        });
+        return true;
+    }
+
     async emitNoteBottomViewModel(file: TFile) {
         const similarNotes = await this.getSimilarNotes(file);
         const settings = this.settingsService.get();

--- a/src/application/__tests__/NoteIndexingService.test.ts
+++ b/src/application/__tests__/NoteIndexingService.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi, beforeEach } from "vitest";
 import { NoteIndexingService } from "../NoteIndexingService";
 import type { NoteChange } from "@/services/noteChangeQueue";
+import { computeIndexableTextHash } from "@/utils/indexableTextHash";
 
 // The user-facing failure Notice is a side-effect, not part of the routing
 // contract. Stub it so the test exercises the real propagation path (in real
@@ -9,6 +10,12 @@ import type { NoteChange } from "@/services/noteChangeQueue";
 vi.mock("@/utils/errorHandling", async (importOriginal) => ({
     ...(await importOriginal<typeof import("@/utils/errorHandling")>()),
     showNoteErrorNotice: vi.fn(),
+}));
+
+vi.mock("@/utils/indexableTextHash", () => ({
+    computeIndexableTextHash: vi.fn(
+        async (content: string) => `hash:${content}`
+    ),
 }));
 
 interface FailureHandler {
@@ -25,6 +32,7 @@ interface ChangeProcessor {
 function makeService() {
     const queue = {
         requeue: vi.fn(),
+        getIndexableTextHash: vi.fn().mockReturnValue(undefined),
         markNoteChangeProcessed: vi.fn().mockResolvedValue(undefined),
     };
     const erroredStore = {
@@ -37,6 +45,7 @@ function makeService() {
         removeByPath: vi.fn().mockResolvedValue(undefined),
         putMulti: vi.fn().mockResolvedValue(undefined),
         count: vi.fn().mockResolvedValue(0),
+        renamePath: vi.fn().mockResolvedValue(false),
     };
     const noteChunkingService = { split: vi.fn() };
     const embeddingService = {
@@ -45,6 +54,7 @@ function makeService() {
     };
     const similarNoteCoordinator = {
         emitNoteBottomViewModelFromPath: vi.fn(),
+        refreshCachedNoteMetadataFromPath: vi.fn().mockResolvedValue(true),
     };
     const settingsService = {
         get: vi
@@ -71,9 +81,32 @@ function makeService() {
         queue,
         erroredStore,
         noteRepository,
+        noteChunkRepository,
         noteChunkingService,
         embeddingService,
+        similarNoteCoordinator,
+        settingsService,
+        app,
     };
+}
+
+beforeEach(() => {
+    vi.mocked(computeIndexableTextHash).mockReset();
+    vi.mocked(computeIndexableTextHash).mockImplementation(
+        async (content) => `hash:${content}`
+    );
+});
+
+function makeChunk(content = "hello world") {
+    const embeddedChunk = { path: "note.md", content, embedding: [0.25] };
+    const chunk = {
+        chunkIndex: 0,
+        title: "Note",
+        content,
+        withEmbedding: vi.fn().mockReturnValue(embeddedChunk),
+    };
+
+    return { chunk, embeddedChunk };
 }
 
 describe("NoteIndexingService retry/errored transition (indexing-status spec §3)", () => {
@@ -149,5 +182,478 @@ describe("NoteIndexingService routes embedding failures through the attempts mac
         // ...and the note must NOT be marked indexed (the #45 root cause: a
         // swallowed embedding error let a failed note be recorded as done).
         expect(queue.markNoteChangeProcessed).not.toHaveBeenCalled();
+    });
+});
+
+describe("NoteIndexingService indexable-text hashing (#51)", () => {
+    test("skips embedding and refreshes only cached active-note metadata when the hash matches", async () => {
+        const {
+            service,
+            queue,
+            noteRepository,
+            noteChunkRepository,
+            noteChunkingService,
+            embeddingService,
+            similarNoteCoordinator,
+            app,
+        } = makeService();
+        const change: NoteChange = {
+            path: "note.md",
+            reason: "modified",
+            mtime: 1234,
+        };
+
+        noteRepository.findByPath.mockResolvedValue({
+            path: "note.md",
+            content: "hello world",
+        });
+        queue.getIndexableTextHash.mockReturnValue("hash:hello world");
+        app.workspace.getActiveFile.mockReturnValue({ path: "note.md" });
+
+        await (service as unknown as ChangeProcessor).processChange(change);
+
+        expect(computeIndexableTextHash).toHaveBeenCalledWith("hello world");
+        expect(noteChunkingService.split).not.toHaveBeenCalled();
+        expect(embeddingService.embedTexts).not.toHaveBeenCalled();
+        expect(noteChunkRepository.removeByPath).not.toHaveBeenCalled();
+        expect(noteChunkRepository.putMulti).not.toHaveBeenCalled();
+        expect(
+            similarNoteCoordinator.emitNoteBottomViewModelFromPath
+        ).not.toHaveBeenCalled();
+        expect(
+            similarNoteCoordinator.refreshCachedNoteMetadataFromPath
+        ).toHaveBeenCalledWith("note.md");
+        expect(queue.markNoteChangeProcessed).toHaveBeenCalledWith(
+            change,
+            "hash:hello world"
+        );
+    });
+
+    test.each([
+        ["changed", "old-hash"],
+        ["legacy hash missing", undefined],
+    ])("embeds when the stored hash is %s", async (_label, storedHash) => {
+        const {
+            service,
+            queue,
+            noteRepository,
+            noteChunkRepository,
+            noteChunkingService,
+            embeddingService,
+        } = makeService();
+        const change: NoteChange = {
+            path: "note.md",
+            reason: "modified",
+            mtime: 1234,
+        };
+        const { chunk, embeddedChunk } = makeChunk();
+
+        noteRepository.findByPath.mockResolvedValue({
+            path: "note.md",
+            content: "hello world",
+        });
+        queue.getIndexableTextHash.mockReturnValue(storedHash);
+        noteChunkingService.split.mockResolvedValue([chunk]);
+        embeddingService.embedTexts.mockResolvedValue([[0.25]]);
+
+        await (service as unknown as ChangeProcessor).processChange(change);
+
+        expect(noteChunkingService.split).toHaveBeenCalledWith({
+            path: "note.md",
+            content: "hello world",
+        });
+        expect(embeddingService.embedTexts).toHaveBeenCalledWith([
+            "Note\n\nhello world",
+        ]);
+        expect(noteChunkRepository.removeByPath).toHaveBeenCalledWith(
+            "note.md"
+        );
+        expect(noteChunkRepository.putMulti).toHaveBeenCalledWith([
+            embeddedChunk,
+        ]);
+        expect(queue.markNoteChangeProcessed).toHaveBeenCalledWith(
+            change,
+            "hash:hello world"
+        );
+    });
+
+    test("backfills a legacy hash so the next unchanged write skips embedding", async () => {
+        const {
+            service,
+            queue,
+            noteRepository,
+            noteChunkingService,
+            embeddingService,
+        } = makeService();
+        const { chunk } = makeChunk();
+        let storedHash: string | undefined;
+
+        noteRepository.findByPath.mockResolvedValue({
+            path: "note.md",
+            content: "hello world",
+        });
+        queue.getIndexableTextHash.mockImplementation(() => storedHash);
+        queue.markNoteChangeProcessed.mockImplementation(
+            async (_change, indexableTextHash) => {
+                storedHash = indexableTextHash;
+            }
+        );
+        noteChunkingService.split.mockResolvedValue([chunk]);
+        embeddingService.embedTexts.mockResolvedValue([[0.25]]);
+
+        await (service as unknown as ChangeProcessor).processChange({
+            path: "note.md",
+            reason: "modified",
+            mtime: 1234,
+        });
+        await (service as unknown as ChangeProcessor).processChange({
+            path: "note.md",
+            reason: "modified",
+            mtime: 1235,
+        });
+
+        expect(embeddingService.embedTexts).toHaveBeenCalledTimes(1);
+        expect(noteChunkingService.split).toHaveBeenCalledTimes(1);
+        expect(queue.markNoteChangeProcessed).toHaveBeenCalledTimes(2);
+        expect(storedHash).toBe("hash:hello world");
+    });
+
+    test("hashes regex-filtered content and skips a regex-only change", async () => {
+        const {
+            service,
+            queue,
+            noteRepository,
+            noteChunkRepository,
+            noteChunkingService,
+            embeddingService,
+            settingsService,
+        } = makeService();
+        const change: NoteChange = {
+            path: "note.md",
+            reason: "modified",
+            mtime: 1234,
+        };
+
+        settingsService.get.mockReturnValue({
+            includeFrontmatter: false,
+            excludeRegexPatterns: ["^secret:.*$"],
+        });
+        noteRepository.findByPath.mockResolvedValue({
+            path: "note.md",
+            content: "keep\nsecret: changed",
+        });
+        queue.getIndexableTextHash.mockReturnValue("hash:keep\n");
+
+        await (service as unknown as ChangeProcessor).processChange(change);
+
+        expect(computeIndexableTextHash).toHaveBeenCalledWith("keep\n");
+        expect(noteChunkingService.split).not.toHaveBeenCalled();
+        expect(embeddingService.embedTexts).not.toHaveBeenCalled();
+        expect(noteChunkRepository.removeByPath).not.toHaveBeenCalled();
+        expect(queue.markNoteChangeProcessed).toHaveBeenCalledWith(
+            change,
+            "hash:keep\n"
+        );
+    });
+
+    test.each([
+        {
+            includeFrontmatter: false,
+            currentContent: "body",
+            storedHash: "hash:body",
+            readWithoutFrontmatter: true,
+            shouldEmbed: false,
+        },
+        {
+            includeFrontmatter: true,
+            currentContent: "---\ntitle: New\n---\nbody",
+            storedHash: "hash:---\ntitle: Old\n---\nbody",
+            readWithoutFrontmatter: false,
+            shouldEmbed: true,
+        },
+    ])(
+        "handles a frontmatter-only write when includeFrontmatter=$includeFrontmatter",
+        async ({
+            includeFrontmatter,
+            currentContent,
+            storedHash,
+            readWithoutFrontmatter,
+            shouldEmbed,
+        }) => {
+            const {
+                service,
+                queue,
+                noteRepository,
+                noteChunkingService,
+                embeddingService,
+                settingsService,
+            } = makeService();
+            const change: NoteChange = {
+                path: "note.md",
+                reason: "modified",
+                mtime: 1234,
+            };
+            const { chunk } = makeChunk(currentContent);
+
+            settingsService.get.mockReturnValue({
+                includeFrontmatter,
+                excludeRegexPatterns: [],
+            });
+            noteRepository.findByPath.mockResolvedValue({
+                path: "note.md",
+                content: currentContent,
+            });
+            queue.getIndexableTextHash.mockReturnValue(storedHash);
+            noteChunkingService.split.mockResolvedValue([chunk]);
+            embeddingService.embedTexts.mockResolvedValue([[0.25]]);
+
+            await (service as unknown as ChangeProcessor).processChange(change);
+
+            expect(noteRepository.findByPath).toHaveBeenCalledWith(
+                "note.md",
+                readWithoutFrontmatter
+            );
+            expect(computeIndexableTextHash).toHaveBeenCalledWith(
+                currentContent
+            );
+            expect(embeddingService.embedTexts).toHaveBeenCalledTimes(
+                shouldEmbed ? 1 : 0
+            );
+            expect(queue.markNoteChangeProcessed).toHaveBeenCalledWith(
+                change,
+                `hash:${currentContent}`
+            );
+        }
+    );
+
+    test("removes stale chunks without embedding when filtered content is empty", async () => {
+        const {
+            service,
+            queue,
+            noteRepository,
+            noteChunkRepository,
+            noteChunkingService,
+            embeddingService,
+            similarNoteCoordinator,
+            settingsService,
+            app,
+        } = makeService();
+        const change: NoteChange = {
+            path: "note.md",
+            reason: "modified",
+            mtime: 1234,
+        };
+
+        settingsService.get.mockReturnValue({
+            includeFrontmatter: false,
+            excludeRegexPatterns: [".+"],
+        });
+        noteRepository.findByPath.mockResolvedValue({
+            path: "note.md",
+            content: "remove all of this",
+        });
+        queue.getIndexableTextHash.mockReturnValue("old-hash");
+        app.workspace.getActiveFile.mockReturnValue({ path: "note.md" });
+
+        await (service as unknown as ChangeProcessor).processChange(change);
+
+        expect(computeIndexableTextHash).toHaveBeenCalledWith("");
+        expect(noteChunkingService.split).not.toHaveBeenCalled();
+        expect(embeddingService.embedTexts).not.toHaveBeenCalled();
+        expect(noteChunkRepository.removeByPath).toHaveBeenCalledWith(
+            "note.md"
+        );
+        expect(
+            similarNoteCoordinator.emitNoteBottomViewModelFromPath
+        ).toHaveBeenCalledWith("note.md");
+        expect(queue.markNoteChangeProcessed).toHaveBeenCalledWith(
+            change,
+            "hash:"
+        );
+    });
+
+    test("removes stale chunks without embedding when the splitter returns no chunks", async () => {
+        const {
+            service,
+            queue,
+            noteRepository,
+            noteChunkRepository,
+            noteChunkingService,
+            embeddingService,
+            similarNoteCoordinator,
+            app,
+        } = makeService();
+        const change: NoteChange = {
+            path: "note.md",
+            reason: "modified",
+            mtime: 1234,
+        };
+
+        noteRepository.findByPath.mockResolvedValue({
+            path: "note.md",
+            content: "non-empty",
+        });
+        queue.getIndexableTextHash.mockReturnValue("old-hash");
+        noteChunkingService.split.mockResolvedValue([]);
+        app.workspace.getActiveFile.mockReturnValue({ path: "note.md" });
+
+        await (service as unknown as ChangeProcessor).processChange(change);
+
+        expect(embeddingService.embedTexts).not.toHaveBeenCalled();
+        expect(noteChunkRepository.removeByPath).toHaveBeenCalledWith(
+            "note.md"
+        );
+        expect(
+            similarNoteCoordinator.emitNoteBottomViewModelFromPath
+        ).toHaveBeenCalledWith("note.md");
+        expect(queue.markNoteChangeProcessed).toHaveBeenCalledWith(
+            change,
+            "hash:non-empty"
+        );
+    });
+
+    test("forceReindex bypasses a matching hash", async () => {
+        const {
+            service,
+            queue,
+            noteRepository,
+            noteChunkRepository,
+            noteChunkingService,
+            embeddingService,
+        } = makeService();
+        const change: NoteChange = {
+            path: "note.md",
+            reason: "modified",
+            mtime: 1234,
+            forceReindex: true,
+        };
+        const { chunk } = makeChunk();
+
+        noteRepository.findByPath.mockResolvedValue({
+            path: "note.md",
+            content: "hello world",
+        });
+        queue.getIndexableTextHash.mockReturnValue("hash:hello world");
+        noteChunkingService.split.mockResolvedValue([chunk]);
+        embeddingService.embedTexts.mockResolvedValue([[0.25]]);
+
+        await (service as unknown as ChangeProcessor).processChange(change);
+
+        expect(embeddingService.embedTexts).toHaveBeenCalledOnce();
+        expect(noteChunkRepository.putMulti).toHaveBeenCalledOnce();
+        expect(queue.markNoteChangeProcessed).toHaveBeenCalledWith(
+            change,
+            "hash:hello world"
+        );
+    });
+
+    test("a hash failure is retried and never marked processed", async () => {
+        const { service, queue, noteRepository, noteChunkingService } =
+            makeService();
+        const change: NoteChange = {
+            path: "note.md",
+            reason: "modified",
+            mtime: 1234,
+        };
+
+        noteRepository.findByPath.mockResolvedValue({
+            path: "note.md",
+            content: "hello world",
+        });
+        vi.mocked(computeIndexableTextHash).mockRejectedValue(
+            new Error("hash failed")
+        );
+
+        await (service as unknown as ChangeProcessor).processChange(change);
+
+        expect(noteChunkingService.split).not.toHaveBeenCalled();
+        expect(queue.requeue).toHaveBeenCalledWith({ ...change, attempts: 1 });
+        expect(queue.markNoteChangeProcessed).not.toHaveBeenCalled();
+    });
+
+    test("a chunk repository failure is retried and never marked processed", async () => {
+        const {
+            service,
+            queue,
+            noteRepository,
+            noteChunkRepository,
+            noteChunkingService,
+            embeddingService,
+        } = makeService();
+        const change: NoteChange = {
+            path: "note.md",
+            reason: "modified",
+            mtime: 1234,
+        };
+        const { chunk } = makeChunk();
+
+        noteRepository.findByPath.mockResolvedValue({
+            path: "note.md",
+            content: "hello world",
+        });
+        noteChunkingService.split.mockResolvedValue([chunk]);
+        embeddingService.embedTexts.mockResolvedValue([[0.25]]);
+        noteChunkRepository.putMulti.mockRejectedValue(
+            new Error("repository failed")
+        );
+
+        await (service as unknown as ChangeProcessor).processChange(change);
+
+        expect(queue.requeue).toHaveBeenCalledWith({ ...change, attempts: 1 });
+        expect(queue.markNoteChangeProcessed).not.toHaveBeenCalled();
+    });
+
+    test("persists a fresh hash when rename fallback must embed", async () => {
+        const {
+            service,
+            queue,
+            noteRepository,
+            noteChunkRepository,
+            noteChunkingService,
+            embeddingService,
+        } = makeService();
+        const change: NoteChange = {
+            path: "new.md",
+            oldPath: "old.md",
+            reason: "renamed",
+            mtime: 1234,
+        };
+        const { chunk } = makeChunk("renamed content");
+
+        noteRepository.findByPath.mockResolvedValue({
+            path: "new.md",
+            content: "renamed content",
+        });
+        noteChunkRepository.renamePath.mockResolvedValue(false);
+        noteChunkingService.split.mockResolvedValue([chunk]);
+        embeddingService.embedTexts.mockResolvedValue([[0.25]]);
+
+        await (service as unknown as ChangeProcessor).processChange(change);
+
+        expect(queue.markNoteChangeProcessed).toHaveBeenCalledWith(
+            change,
+            "hash:renamed content"
+        );
+    });
+
+    test("leaves hash carrying to the queue after a pure rename", async () => {
+        const { service, queue, noteChunkRepository } = makeService();
+        const change: NoteChange = {
+            path: "new.md",
+            oldPath: "old.md",
+            reason: "renamed",
+            mtime: 1234,
+        };
+
+        noteChunkRepository.renamePath.mockResolvedValue(true);
+
+        await (service as unknown as ChangeProcessor).processChange(change);
+
+        expect(computeIndexableTextHash).not.toHaveBeenCalled();
+        expect(queue.getIndexableTextHash).not.toHaveBeenCalled();
+        expect(queue.markNoteChangeProcessed).toHaveBeenCalledWith(
+            change,
+            undefined
+        );
     });
 });

--- a/src/application/__tests__/SimilarNoteCoordinator.test.ts
+++ b/src/application/__tests__/SimilarNoteCoordinator.test.ts
@@ -272,4 +272,171 @@ describe("SimilarNoteCoordinator", () => {
             expect(seen.at(-1)).toBe(2); // high + mid pass; low is dropped
         });
     });
+
+    describe("#51: unchanged indexable text", () => {
+        test("refreshes cached linked state without repeating similarity search", async () => {
+            const activeFile = makeFile("open.md", 1);
+            const updatedFile = makeFile("open.md", 2);
+            (vault.getFileByPath as ReturnType<typeof vi.fn>)
+                .mockImplementation((path: string) =>
+                    path === "open.md" ? updatedFile : makeFile(path)
+                );
+            (
+                similarNoteFinder.findSimilarNotes as ReturnType<typeof vi.fn>
+            ).mockResolvedValue([
+                {
+                    title: "Linked",
+                    path: "linked.md",
+                    similarity: 0.9,
+                    similarChunk: "related",
+                    sourceChunk: "source",
+                    isLinked: false,
+                },
+            ]);
+
+            const coord = new SimilarNoteCoordinator(
+                vault,
+                noteRepository,
+                similarNoteFinder,
+                settingsService
+            );
+            await coord.onFileOpen(activeFile);
+
+            (noteRepository.findByFile as ReturnType<typeof vi.fn>)
+                .mockResolvedValue({
+                    path: "open.md",
+                    title: "open",
+                    content: "body",
+                    links: ["linked.md"],
+                });
+
+            await expect(
+                coord.refreshCachedNoteMetadataFromPath("open.md")
+            ).resolves.toBe(true);
+
+            expect(similarNoteFinder.findSimilarNotes).toHaveBeenCalledOnce();
+            expect(
+                coord["noteBottomViewModel$"].value.similarNoteEntries[0]
+                    .isLinked
+            ).toBe(true);
+        });
+
+        test("refreshes visible linked state after settings clear the cache", async () => {
+            const activeFile = makeFile("open.md", 1);
+            const updatedFile = makeFile("open.md", 2);
+            (vault.getFileByPath as ReturnType<typeof vi.fn>)
+                .mockImplementation((path: string) =>
+                    path === "open.md" ? updatedFile : makeFile(path)
+                );
+            (
+                similarNoteFinder.findSimilarNotes as ReturnType<typeof vi.fn>
+            ).mockResolvedValue([
+                {
+                    title: "Linked",
+                    path: "linked.md",
+                    similarity: 0.9,
+                    similarChunk: "related",
+                    sourceChunk: "source",
+                    isLinked: false,
+                },
+            ]);
+
+            const coord = new SimilarNoteCoordinator(
+                vault,
+                noteRepository,
+                similarNoteFinder,
+                settingsService
+            );
+            await coord.onFileOpen(activeFile);
+            settingsChange$.next({ includeFrontmatter: false });
+
+            (noteRepository.findByFile as ReturnType<typeof vi.fn>)
+                .mockResolvedValue({
+                    path: "open.md",
+                    title: "open",
+                    content: "body",
+                    links: ["linked.md"],
+                });
+
+            await expect(
+                coord.refreshCachedNoteMetadataFromPath("open.md")
+            ).resolves.toBe(true);
+
+            expect(similarNoteFinder.findSimilarNotes).toHaveBeenCalledOnce();
+            expect(
+                coord["noteBottomViewModel$"].value.similarNoteEntries[0]
+                    .isLinked
+            ).toBe(true);
+        });
+
+        test("does not replace a newly opened note while metadata refresh awaits", async () => {
+            const activeFile = makeFile("open.md", 1);
+            const updatedFile = makeFile("open.md", 2);
+            const nextFile = makeFile("next.md", 3);
+            (vault.getFileByPath as ReturnType<typeof vi.fn>)
+                .mockImplementation((path: string) =>
+                    path === "open.md" ? updatedFile : makeFile(path)
+                );
+            (
+                similarNoteFinder.findSimilarNotes as ReturnType<typeof vi.fn>
+            ).mockResolvedValue([
+                {
+                    title: "Linked",
+                    path: "linked.md",
+                    similarity: 0.9,
+                    similarChunk: "related",
+                    sourceChunk: "source",
+                    isLinked: false,
+                },
+            ]);
+
+            const coord = new SimilarNoteCoordinator(
+                vault,
+                noteRepository,
+                similarNoteFinder,
+                settingsService
+            );
+            await coord.onFileOpen(activeFile);
+
+            let resolveActiveRead: ((value: {
+                path: string;
+                title: string;
+                content: string;
+                links: string[];
+            }) => void) | undefined;
+            const activeRead = new Promise<{
+                path: string;
+                title: string;
+                content: string;
+                links: string[];
+            }>((resolve) => {
+                resolveActiveRead = resolve;
+            });
+            (noteRepository.findByFile as ReturnType<typeof vi.fn>)
+                .mockImplementation((file: TFile) =>
+                    file.path === "open.md"
+                        ? activeRead
+                        : Promise.resolve({
+                            path: file.path,
+                            title: file.basename,
+                            content: "next body",
+                            links: [],
+                        })
+                );
+
+            const refresh = coord.refreshCachedNoteMetadataFromPath("open.md");
+            await coord.onFileOpen(nextFile);
+            resolveActiveRead?.({
+                path: "open.md",
+                title: "open",
+                content: "body",
+                links: ["linked.md"],
+            });
+            await refresh;
+
+            expect(
+                coord["noteBottomViewModel$"].value.currentFile?.path
+            ).toBe("next.md");
+        });
+    });
 });

--- a/src/infrastructure/IndexedDBMTimeStorage.ts
+++ b/src/infrastructure/IndexedDBMTimeStorage.ts
@@ -6,6 +6,7 @@ import log from "loglevel";
 export interface MTimeEntry {
     path: string; // Primary key
     mtime: number; // Last modified timestamp
+    indexableTextHash?: string; // Hash of text used for embedding
 }
 
 /**
@@ -77,7 +78,7 @@ export class IndexedDBMTimeStorage {
     /**
      * Get modification time for a specific path
      */
-    async get(path: string): Promise<number | undefined> {
+    async get(path: string): Promise<MTimeEntry | undefined> {
         this.ensureInitialized();
         const db = this.db;
         if (!db) {
@@ -94,7 +95,7 @@ export class IndexedDBMTimeStorage {
 
             request.onsuccess = () => {
                 const entry = request.result as MTimeEntry | undefined;
-                resolve(entry?.mtime);
+                resolve(entry);
             };
 
             request.onerror = () => {
@@ -107,7 +108,11 @@ export class IndexedDBMTimeStorage {
     /**
      * Set modification time for a specific path
      */
-    async set(path: string, mtime: number): Promise<void> {
+    async set(
+        path: string,
+        mtime: number,
+        indexableTextHash?: string
+    ): Promise<void> {
         this.ensureInitialized();
         const db = this.db;
         if (!db) {
@@ -121,15 +126,58 @@ export class IndexedDBMTimeStorage {
             );
             const store = transaction.objectStore(this.mtimesStoreName);
             const entry: MTimeEntry = { path, mtime };
+            if (indexableTextHash !== undefined) {
+                entry.indexableTextHash = indexableTextHash;
+            }
             const request = store.put(entry);
 
-            request.onsuccess = () => {
-                resolve();
-            };
+            transaction.oncomplete = () => resolve();
 
             request.onerror = () => {
                 log.error("Failed to set mtime:", request.error);
                 reject(request.error);
+            };
+            transaction.onabort = () => reject(transaction.error);
+        });
+    }
+
+    /**
+     * Move metadata to a new path in a single transaction
+     */
+    async move(
+        oldPath: string,
+        newPath: string,
+        mtime: number,
+        indexableTextHash?: string
+    ): Promise<void> {
+        this.ensureInitialized();
+        const db = this.db;
+        if (!db) {
+            throw new Error("Database not initialized");
+        }
+
+        return new Promise((resolve, reject) => {
+            const transaction = db.transaction(
+                [this.mtimesStoreName],
+                "readwrite"
+            );
+            const store = transaction.objectStore(this.mtimesStoreName);
+            const entry: MTimeEntry = { path: newPath, mtime };
+            if (indexableTextHash !== undefined) {
+                entry.indexableTextHash = indexableTextHash;
+            }
+
+            store.delete(oldPath);
+            store.put(entry);
+
+            transaction.oncomplete = () => resolve();
+            transaction.onerror = () => {
+                log.error("Failed to move note metadata:", transaction.error);
+                reject(transaction.error);
+            };
+            transaction.onabort = () => {
+                log.error("Failed to move note metadata:", transaction.error);
+                reject(transaction.error);
             };
         });
     }
@@ -152,21 +200,20 @@ export class IndexedDBMTimeStorage {
             const store = transaction.objectStore(this.mtimesStoreName);
             const request = store.delete(path);
 
-            request.onsuccess = () => {
-                resolve();
-            };
+            transaction.oncomplete = () => resolve();
 
             request.onerror = () => {
                 log.error("Failed to delete mtime:", request.error);
                 reject(request.error);
             };
+            transaction.onabort = () => reject(transaction.error);
         });
     }
 
     /**
      * Get all modification times as a map
      */
-    async getAll(): Promise<Record<string, number>> {
+    async getAll(): Promise<Record<string, MTimeEntry>> {
         this.ensureInitialized();
         const db = this.db;
         if (!db) {
@@ -183,9 +230,9 @@ export class IndexedDBMTimeStorage {
 
             request.onsuccess = () => {
                 const entries = request.result as MTimeEntry[];
-                const mtimes: Record<string, number> = {};
+                const mtimes: Record<string, MTimeEntry> = {};
                 for (const entry of entries) {
-                    mtimes[entry.path] = entry.mtime;
+                    mtimes[entry.path] = entry;
                 }
                 resolve(mtimes);
             };
@@ -215,7 +262,7 @@ export class IndexedDBMTimeStorage {
             const store = transaction.objectStore(this.mtimesStoreName);
             const request = store.clear();
 
-            request.onsuccess = () => {
+            transaction.oncomplete = () => {
                 log.info("Cleared all mtimes from IndexedDB");
                 resolve();
             };
@@ -224,6 +271,7 @@ export class IndexedDBMTimeStorage {
                 log.error("Failed to clear mtimes:", request.error);
                 reject(request.error);
             };
+            transaction.onabort = () => reject(transaction.error);
         });
     }
 

--- a/src/infrastructure/IndexedNoteMTimeStore.ts
+++ b/src/infrastructure/IndexedNoteMTimeStore.ts
@@ -1,9 +1,12 @@
 import log from "loglevel";
 import { BehaviorSubject, type Observable } from "rxjs";
-import { IndexedDBMTimeStorage } from "./IndexedDBMTimeStorage";
+import {
+    IndexedDBMTimeStorage,
+    type MTimeEntry,
+} from "./IndexedDBMTimeStorage";
 
 export class IndexedNoteMTimeStore {
-    private mtimes: Record<string, number> = {};
+    private entries: Record<string, MTimeEntry> = {};
     private indexedNoteCount$ = new BehaviorSubject<number>(0);
     private storage: IndexedDBMTimeStorage;
     private vaultId = "";
@@ -22,9 +25,9 @@ export class IndexedNoteMTimeStore {
         // Initialize IndexedDB storage
         await this.storage.init(vaultId);
 
-        // Load all mtimes from IndexedDB to memory cache
-        this.mtimes = await this.storage.getAll();
-        const noteCount = Object.keys(this.mtimes).length;
+        // Load all note metadata from IndexedDB to memory cache
+        this.entries = await this.storage.getAll();
+        const noteCount = Object.keys(this.entries).length;
         this.indexedNoteCount$.next(noteCount);
         log.info("Loaded", noteCount, "modification times from IndexedDB");
     }
@@ -34,46 +37,78 @@ export class IndexedNoteMTimeStore {
      * Used when reindexing all notes
      */
     async clear(): Promise<void> {
-        this.mtimes = {};
-        this.indexedNoteCount$.next(0);
         await this.storage.clear();
+        this.entries = {};
+        this.indexedNoteCount$.next(0);
         log.info("Cleared all stored modification times");
     }
 
     getMTime(path: string): number {
-        return this.mtimes[path];
+        return this.entries[path]?.mtime;
+    }
+
+    getIndexableTextHash(path: string): string | undefined {
+        return this.entries[path]?.indexableTextHash;
     }
 
     async setMTime(path: string, mtime: number): Promise<void> {
-        const isNewPath = this.mtimes[path] === undefined;
-        this.mtimes[path] = mtime;
+        await this.setMetadata(
+            path,
+            mtime,
+            this.entries[path]?.indexableTextHash
+        );
+    }
+
+    async setMetadata(
+        path: string,
+        mtime: number,
+        indexableTextHash?: string
+    ): Promise<void> {
+        const entry: MTimeEntry = { path, mtime };
+        if (indexableTextHash !== undefined) {
+            entry.indexableTextHash = indexableTextHash;
+        }
 
         // Save to IndexedDB
-        await this.storage.set(path, mtime);
+        await this.storage.set(path, mtime, indexableTextHash);
+        this.entries[path] = entry;
+        this.indexedNoteCount$.next(Object.keys(this.entries).length);
+    }
 
-        // If this is a new path, increment the count
-        if (isNewPath) {
-            const currentCount = this.indexedNoteCount$.getValue();
-            this.indexedNoteCount$.next(currentCount + 1);
+    async moveMetadata(
+        oldPath: string,
+        newPath: string,
+        mtime: number,
+        hashOverride?: string
+    ): Promise<void> {
+        const indexableTextHash =
+            hashOverride ?? this.entries[oldPath]?.indexableTextHash;
+
+        await this.storage.move(
+            oldPath,
+            newPath,
+            mtime,
+            indexableTextHash
+        );
+
+        const entry: MTimeEntry = { path: newPath, mtime };
+        if (indexableTextHash !== undefined) {
+            entry.indexableTextHash = indexableTextHash;
         }
+        delete this.entries[oldPath];
+        this.entries[newPath] = entry;
+        this.indexedNoteCount$.next(Object.keys(this.entries).length);
     }
 
     async deleteMTime(path: string): Promise<void> {
-        const existed = this.mtimes[path] !== undefined;
-        delete this.mtimes[path];
-
         // Delete from IndexedDB
         await this.storage.delete(path);
-
-        // If the path existed, decrement the count
-        if (existed) {
-            const currentCount = this.indexedNoteCount$.getValue();
-            this.indexedNoteCount$.next(currentCount - 1);
-        }
+        delete this.entries[path];
+        this.indexedNoteCount$.next(Object.keys(this.entries).length);
     }
 
     getAllPaths(): string[] {
-        return Object.keys(this.mtimes);
+        return Object.keys(this.entries);
     }
 
     /**

--- a/src/infrastructure/__tests__/IndexedDBMTimeStorage.test.ts
+++ b/src/infrastructure/__tests__/IndexedDBMTimeStorage.test.ts
@@ -1,0 +1,254 @@
+import "fake-indexeddb/auto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    IndexedDBMTimeStorage,
+    type MTimeEntry,
+} from "../IndexedDBMTimeStorage";
+import { IndexedNoteMTimeStore } from "../IndexedNoteMTimeStore";
+
+let vaultSequence = 0;
+
+function getBackingStorage(store: IndexedNoteMTimeStore): IndexedDBMTimeStorage {
+    return (
+        store as unknown as {
+            storage: IndexedDBMTimeStorage;
+        }
+    ).storage;
+}
+
+function deleteDatabase(name: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const request = indexedDB.deleteDatabase(name);
+        request.onsuccess = () => resolve();
+        request.onerror = () => reject(request.error);
+        request.onblocked = () =>
+            reject(new Error(`Database deletion blocked: ${name}`));
+    });
+}
+
+describe("IndexedDBMTimeStorage", () => {
+    let vaultId: string;
+    let storages: IndexedDBMTimeStorage[];
+    let stores: IndexedNoteMTimeStore[];
+
+    const createStorage = (): IndexedDBMTimeStorage => {
+        const storage = new IndexedDBMTimeStorage();
+        storages.push(storage);
+        return storage;
+    };
+
+    const createStore = (): IndexedNoteMTimeStore => {
+        const store = new IndexedNoteMTimeStore();
+        stores.push(store);
+        return store;
+    };
+
+    beforeEach(() => {
+        vaultId = `mtime-test-${vaultSequence++}`;
+        storages = [];
+        stores = [];
+    });
+
+    afterEach(async () => {
+        for (const store of stores) {
+            getBackingStorage(store).close();
+        }
+        for (const storage of storages) {
+            storage.close();
+        }
+        await deleteDatabase(`${vaultId}-similar-notes-mtimes`);
+    });
+
+    it("persists complete entries across reloads", async () => {
+        let storage = createStorage();
+        await storage.init(vaultId);
+        await storage.set("folder/note.md", 123, "v1:abc123");
+        storage.close();
+
+        storage = createStorage();
+        await storage.init(vaultId);
+
+        const expected: MTimeEntry = {
+            path: "folder/note.md",
+            mtime: 123,
+            indexableTextHash: "v1:abc123",
+        };
+        expect(await storage.get("folder/note.md")).toEqual(expected);
+        expect(await storage.getAll()).toEqual({
+            "folder/note.md": expected,
+        });
+    });
+
+    it("loads legacy records without a hash", async () => {
+        const storage = createStorage();
+        await storage.init(vaultId);
+        await storage.set("legacy.md", 456);
+
+        expect(await storage.get("legacy.md")).toEqual({
+            path: "legacy.md",
+            mtime: 456,
+        });
+        expect((await storage.getAll())["legacy.md"].indexableTextHash).toBe(
+            undefined
+        );
+    });
+
+    it("moves complete metadata between paths", async () => {
+        const storage = createStorage();
+        await storage.init(vaultId);
+        await storage.set("old.md", 100, "v1:old");
+
+        await storage.move("old.md", "new.md", 200, "v1:old");
+
+        expect(await storage.get("old.md")).toBeUndefined();
+        expect(await storage.get("new.md")).toEqual({
+            path: "new.md",
+            mtime: 200,
+            indexableTextHash: "v1:old",
+        });
+    });
+
+    it("deletes and clears complete metadata records", async () => {
+        const storage = createStorage();
+        await storage.init(vaultId);
+        await storage.set("one.md", 1, "v1:one");
+        await storage.set("two.md", 2, "v1:two");
+
+        await storage.delete("one.md");
+        expect(await storage.get("one.md")).toBeUndefined();
+        expect(await storage.get("two.md")).toBeDefined();
+
+        await storage.clear();
+        expect(await storage.getAll()).toEqual({});
+    });
+
+    it("restores complete and legacy entries into the in-memory store", async () => {
+        const storage = createStorage();
+        await storage.init(vaultId);
+        await storage.set("hashed.md", 10, "v1:hash");
+        await storage.set("legacy.md", 20);
+        storage.close();
+
+        const store = createStore();
+        await store.init(vaultId);
+
+        expect(store.getMTime("hashed.md")).toBe(10);
+        expect(store.getIndexableTextHash("hashed.md")).toBe("v1:hash");
+        expect(store.getMTime("legacy.md")).toBe(20);
+        expect(store.getIndexableTextHash("legacy.md")).toBeUndefined();
+        expect(store.getAllPaths()).toEqual(
+            expect.arrayContaining(["hashed.md", "legacy.md"])
+        );
+        expect(store.getCurrentIndexedNoteCount()).toBe(2);
+    });
+
+    it("keeps a stored hash when the compatibility mtime API is used", async () => {
+        const store = createStore();
+        await store.init(vaultId);
+        await store.setMetadata("note.md", 10, "v1:hash");
+
+        await store.setMTime("note.md", 20);
+
+        expect(store.getMTime("note.md")).toBe(20);
+        expect(store.getIndexableTextHash("note.md")).toBe("v1:hash");
+        expect(await getBackingStorage(store).get("note.md")).toEqual({
+            path: "note.md",
+            mtime: 20,
+            indexableTextHash: "v1:hash",
+        });
+    });
+
+    it("carries or overrides hashes while moving store metadata", async () => {
+        const store = createStore();
+        await store.init(vaultId);
+        await store.setMetadata("old.md", 10, "v1:old");
+
+        await store.moveMetadata("old.md", "new.md", 20);
+        expect(store.getMTime("old.md")).toBeUndefined();
+        expect(store.getIndexableTextHash("new.md")).toBe("v1:old");
+
+        await store.moveMetadata("new.md", "overridden.md", 30, "v1:new");
+        expect(store.getIndexableTextHash("overridden.md")).toBe("v1:new");
+        expect(store.getCurrentIndexedNoteCount()).toBe(1);
+        expect(await getBackingStorage(store).getAll()).toEqual({
+            "overridden.md": {
+                path: "overridden.md",
+                mtime: 30,
+                indexableTextHash: "v1:new",
+            },
+        });
+    });
+
+    it("removes hashes from memory and storage on delete and clear", async () => {
+        const store = createStore();
+        await store.init(vaultId);
+        await store.setMetadata("one.md", 1, "v1:one");
+        await store.setMetadata("two.md", 2, "v1:two");
+
+        await store.deleteMTime("one.md");
+        expect(store.getIndexableTextHash("one.md")).toBeUndefined();
+        expect(await getBackingStorage(store).get("one.md")).toBeUndefined();
+
+        await store.clear();
+        expect(store.getAllPaths()).toEqual([]);
+        expect(store.getCurrentIndexedNoteCount()).toBe(0);
+        expect(await getBackingStorage(store).getAll()).toEqual({});
+    });
+
+    it("keeps the indexed-note count correct for concurrent writes to one path", async () => {
+        const store = createStore();
+        await store.init(vaultId);
+
+        await Promise.all([
+            store.setMetadata("same.md", 1, "v1:first"),
+            store.setMetadata("same.md", 2, "v1:second"),
+        ]);
+
+        expect(store.getAllPaths()).toEqual(["same.md"]);
+        expect(store.getCurrentIndexedNoteCount()).toBe(1);
+
+        await Promise.all([
+            store.deleteMTime("same.md"),
+            store.deleteMTime("same.md"),
+        ]);
+
+        expect(store.getAllPaths()).toEqual([]);
+        expect(store.getCurrentIndexedNoteCount()).toBe(0);
+    });
+
+    it("mutates the cache only after persistent writes succeed", async () => {
+        const store = createStore();
+        await store.init(vaultId);
+        const storage = getBackingStorage(store);
+        vi.spyOn(storage, "set").mockRejectedValueOnce(
+            new Error("write failed")
+        );
+
+        await expect(
+            store.setMetadata("failed.md", 1, "v1:failed")
+        ).rejects.toThrow("write failed");
+
+        expect(store.getMTime("failed.md")).toBeUndefined();
+        expect(store.getIndexableTextHash("failed.md")).toBeUndefined();
+        expect(store.getCurrentIndexedNoteCount()).toBe(0);
+    });
+
+    it("keeps old cached metadata when a persistent move fails", async () => {
+        const store = createStore();
+        await store.init(vaultId);
+        await store.setMetadata("old.md", 1, "v1:old");
+        const storage = getBackingStorage(store);
+        vi.spyOn(storage, "move").mockRejectedValueOnce(
+            new Error("move failed")
+        );
+
+        await expect(
+            store.moveMetadata("old.md", "new.md", 2)
+        ).rejects.toThrow("move failed");
+
+        expect(store.getMTime("old.md")).toBe(1);
+        expect(store.getIndexableTextHash("old.md")).toBe("v1:old");
+        expect(store.getMTime("new.md")).toBeUndefined();
+        expect(store.getCurrentIndexedNoteCount()).toBe(1);
+    });
+});

--- a/src/services/__tests__/noteChangeQueue.test.ts
+++ b/src/services/__tests__/noteChangeQueue.test.ts
@@ -78,7 +78,10 @@ describe("FileChangeQueue", () => {
         };
         mockMTimeStore = {
             getMTime: vi.fn().mockReturnValue(undefined),
+            getIndexableTextHash: vi.fn().mockReturnValue(undefined),
             setMTime: vi.fn(),
+            setMetadata: vi.fn(),
+            moveMetadata: vi.fn(),
             deleteMTime: vi.fn(),
             getAllPaths: vi.fn().mockReturnValue([]),
         } as unknown as IndexedNoteMTimeStore;
@@ -155,6 +158,7 @@ describe("FileChangeQueue", () => {
             const queued = fileChangeQueue.pollFileChanges(100);
             expect(queued.map((c) => c.path)).toEqual(["file1.md"]);
             expect(queued[0].attempts ?? 0).toBe(0); // fresh attempt budget
+            expect(queued[0].forceReindex).toBe(true);
             expect(mockErroredStore.clear).toHaveBeenCalled();
         });
     });
@@ -210,9 +214,11 @@ describe("FileChangeQueue", () => {
         expect(changes[0].path).toBe("file1.md");
         expect(changes[0].reason).toBe("modified");
         expect(changes[0].mtime).toBe(1000);
+        expect(changes[0].forceReindex).toBeUndefined();
         expect(changes[1].path).toBe("file2.md");
         expect(changes[1].reason).toBe("modified");
         expect(changes[1].mtime).toBe(2000);
+        expect(changes[1].forceReindex).toBeUndefined();
     });
 
     test("should detect deleted files", async () => {
@@ -249,9 +255,11 @@ describe("FileChangeQueue", () => {
         expect(changes[0].path).toBe("file1.md");
         expect(changes[0].reason).toBe("modified");
         expect(changes[0].mtime).toBe(1000);
+        expect(changes[0].forceReindex).toBe(true);
         expect(changes[1].path).toBe("file2.md");
         expect(changes[1].reason).toBe("modified");
         expect(changes[1].mtime).toBe(2000);
+        expect(changes[1].forceReindex).toBe(true);
     });
 
     test("should poll changes from the queue", async () => {
@@ -277,6 +285,32 @@ describe("FileChangeQueue", () => {
         expect(changes[1].mtime).toBe(2000);
         expect(changes[2].path).toBe("file3.md");
         expect(changes[2].reason).toBe("deleted");
+    });
+
+    test("should expose the stored indexable-text hash", () => {
+        mockMTimeStore.getIndexableTextHash = vi
+            .fn()
+            .mockReturnValue("v1:stored");
+
+        expect(fileChangeQueue.getIndexableTextHash("file1.md")).toBe(
+            "v1:stored"
+        );
+        expect(mockMTimeStore.getIndexableTextHash).toHaveBeenCalledWith(
+            "file1.md"
+        );
+    });
+
+    test("requeue preserves the force-reindex flag", () => {
+        const change = {
+            path: "file1.md",
+            reason: "modified" as const,
+            mtime: 1000,
+            forceReindex: true,
+        };
+
+        fileChangeQueue.requeue(change);
+
+        expect(fileChangeQueue.pollFileChanges(1)).toEqual([change]);
     });
 
     describe("file change event callbacks", () => {
@@ -503,7 +537,7 @@ describe("FileChangeQueue", () => {
     });
 
     describe("markFileChangeProcessed", () => {
-        test("should update mtime store for new files", async () => {
+        test("should persist mtime and hash for new files", async () => {
             // Create a file change
             const change = {
                 path: "file1.md",
@@ -511,14 +545,15 @@ describe("FileChangeQueue", () => {
                 mtime: 1234,
             };
             // Mark the change as processed
-            await fileChangeQueue.markNoteChangeProcessed(change);
-            expect(mockMTimeStore.setMTime).toHaveBeenCalledWith(
+            await fileChangeQueue.markNoteChangeProcessed(change, "v1:new");
+            expect(mockMTimeStore.setMetadata).toHaveBeenCalledWith(
                 "file1.md",
-                1234
+                1234,
+                "v1:new"
             );
         });
 
-        test("should update mtime store for modified files", async () => {
+        test("should persist mtime and hash for modified files", async () => {
             // Create a file change
             const change = {
                 path: "file1.md",
@@ -526,10 +561,27 @@ describe("FileChangeQueue", () => {
                 mtime: 2345,
             };
             // Mark the change as processed
-            await fileChangeQueue.markNoteChangeProcessed(change);
-            expect(mockMTimeStore.setMTime).toHaveBeenCalledWith(
+            await fileChangeQueue.markNoteChangeProcessed(change, "v1:modified");
+            expect(mockMTimeStore.setMetadata).toHaveBeenCalledWith(
                 "file1.md",
-                2345
+                2345,
+                "v1:modified"
+            );
+        });
+
+        test("should persist a zero mtime", async () => {
+            const change = {
+                path: "file1.md",
+                reason: "modified" as const,
+                mtime: 0,
+            };
+
+            await fileChangeQueue.markNoteChangeProcessed(change, "v1:zero");
+
+            expect(mockMTimeStore.setMetadata).toHaveBeenCalledWith(
+                "file1.md",
+                0,
+                "v1:zero"
             );
         });
 
@@ -541,7 +593,7 @@ describe("FileChangeQueue", () => {
             expect(mockMTimeStore.deleteMTime).toHaveBeenCalledWith("file1.md");
         });
 
-        test("#39.5: renamed change transfers mtime from oldPath to newPath in one step", async () => {
+        test("#39.5: pure rename atomically carries metadata from oldPath", async () => {
             const change = {
                 path: "renamed.md",
                 reason: "renamed" as const,
@@ -549,10 +601,30 @@ describe("FileChangeQueue", () => {
                 mtime: 1000,
             };
             await fileChangeQueue.markNoteChangeProcessed(change);
-            expect(mockMTimeStore.deleteMTime).toHaveBeenCalledWith("file1.md");
-            expect(mockMTimeStore.setMTime).toHaveBeenCalledWith(
+            expect(mockMTimeStore.moveMetadata).toHaveBeenCalledWith(
+                "file1.md",
                 "renamed.md",
-                1000
+                1000,
+                undefined
+            );
+            expect(mockMTimeStore.deleteMTime).not.toHaveBeenCalled();
+        });
+
+        test("pure rename uses a freshly computed hash override", async () => {
+            const change = {
+                path: "renamed.md",
+                reason: "renamed" as const,
+                oldPath: "file1.md",
+                mtime: 1000,
+            };
+
+            await fileChangeQueue.markNoteChangeProcessed(change, "v1:fresh");
+
+            expect(mockMTimeStore.moveMetadata).toHaveBeenCalledWith(
+                "file1.md",
+                "renamed.md",
+                1000,
+                "v1:fresh"
             );
         });
     });
@@ -582,7 +654,10 @@ describe("FileChangeQueue", () => {
             };
             mockMTimeStore = {
                 getMTime: vi.fn(),
+                getIndexableTextHash: vi.fn(),
                 setMTime: vi.fn(),
+                setMetadata: vi.fn(),
+                moveMetadata: vi.fn(),
                 deleteMTime: vi.fn(),
                 getAllPaths: vi.fn(),
             } as unknown as IndexedNoteMTimeStore;

--- a/src/services/noteChangeQueue.ts
+++ b/src/services/noteChangeQueue.ts
@@ -16,6 +16,8 @@ export type NoteChange = {
     // How many processing attempts this change has already had. Used to cap
     // in-session retries before a note is moved to the terminal Errored state.
     attempts?: number;
+    // Explicit reindex requests must bypass the unchanged-content hash check.
+    forceReindex?: boolean;
 };
 
 interface FileInfo {
@@ -254,6 +256,7 @@ export class NoteChangeQueue {
                 path: file.path,
                 reason: "modified",
                 mtime: file.stat.mtime,
+                forceReindex: true,
             });
         }
         
@@ -278,6 +281,7 @@ export class NoteChangeQueue {
                     path,
                     reason: "modified",
                     mtime: file.stat.mtime,
+                    forceReindex: true,
                 });
             }
         }
@@ -312,6 +316,13 @@ export class NoteChangeQueue {
      */
     getFileChangeCount(): number {
         return this.queue.length;
+    }
+
+    /**
+     * Returns the hash of the indexable text persisted for a note, if any.
+     */
+    getIndexableTextHash(path: string): string | undefined {
+        return this.mTimeStore.getIndexableTextHash(path);
     }
 
     /**
@@ -423,19 +434,35 @@ export class NoteChangeQueue {
      * This should be called after processing a file change to ensure it's not reprocessed
      * if the application restarts before the hash store is updated
      */
-    async markNoteChangeProcessed(change: NoteChange): Promise<void> {
+    async markNoteChangeProcessed(
+        change: NoteChange,
+        indexableTextHash?: string
+    ): Promise<void> {
         if (change.reason === "deleted") {
             await this.mTimeStore.deleteMTime(change.path);
         } else if (change.reason === "renamed") {
-            if (change.oldPath) {
+            if (change.oldPath && change.mtime !== undefined) {
+                await this.mTimeStore.moveMetadata(
+                    change.oldPath,
+                    change.path,
+                    change.mtime,
+                    indexableTextHash
+                );
+            } else if (change.mtime !== undefined) {
+                await this.mTimeStore.setMetadata(
+                    change.path,
+                    change.mtime,
+                    indexableTextHash
+                );
+            } else if (change.oldPath) {
                 await this.mTimeStore.deleteMTime(change.oldPath);
             }
-            if (change.mtime) {
-                await this.mTimeStore.setMTime(change.path, change.mtime);
-            }
-        } else if (change.mtime) {
-            // Update the hash store with the processed hash
-            await this.mTimeStore.setMTime(change.path, change.mtime);
+        } else if (change.mtime !== undefined) {
+            await this.mTimeStore.setMetadata(
+                change.path,
+                change.mtime,
+                indexableTextHash
+            );
         }
     }
 

--- a/src/utils/__tests__/indexableTextHash.test.ts
+++ b/src/utils/__tests__/indexableTextHash.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { computeIndexableTextHash } from "../indexableTextHash";
+
+describe("computeIndexableTextHash", () => {
+    it("returns a versioned SHA-256 hex digest", async () => {
+        await expect(computeIndexableTextHash("hello")).resolves.toBe(
+            "v1:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+    });
+
+    it("hashes empty text exactly", async () => {
+        await expect(computeIndexableTextHash("")).resolves.toBe(
+            "v1:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    });
+
+    it("does not normalize indexable text", async () => {
+        const plain = await computeIndexableTextHash("note");
+        const trailingNewline = await computeIndexableTextHash("note\n");
+
+        expect(trailingNewline).not.toBe(plain);
+    });
+});

--- a/src/utils/indexableTextHash.ts
+++ b/src/utils/indexableTextHash.ts
@@ -1,0 +1,14 @@
+const HASH_VERSION = "v1";
+
+/**
+ * Hash effective indexable text after exclusions and before chunking.
+ */
+export async function computeIndexableTextHash(text: string): Promise<string> {
+    const encoded = new TextEncoder().encode(text);
+    const digest = await crypto.subtle.digest("SHA-256", encoded);
+    const hex = Array.from(new Uint8Array(digest), (byte) =>
+        byte.toString(16).padStart(2, "0")
+    ).join("");
+
+    return `${HASH_VERSION}:${hex}`;
+}


### PR DESCRIPTION
## Why

File mtime can change without changing embedding input—for example, when another
plugin updates excluded frontmatter or regex-filtered content. Re-embedding that
note wastes local CPU or remote-provider usage.

Closes #51.

## What

- Keep mtime as the initial change detector; hash only already-queued notes.
- Hash exact text after frontmatter and regex exclusions, before chunking, using
  versioned SHA-256 (`v1:<hex>`).
- On a match, skip chunking, embedding, and index writes while advancing mtime.
- Store the optional hash with existing IndexedDB mtime metadata. Legacy records
  embed once on their next modification, then backfill the hash.
- Force full reindex/retry, carry hashes across pure renames, and clear them on
  delete or index reset.
- Remove stale chunks for empty/fully excluded content without embedding.
- Refresh active-note link metadata without repeating vector search.

## Scope

- No settings, UI, dependencies, database-version bump, or release-version bump.
- No startup scan or eager migration.
- Adds an implementation spec, architecture reference, tests, and an
  `Unreleased` changelog entry.

## Test plan

### Automated

- [x] `npm run test`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`

Coverage includes unchanged/changed/legacy hashes, frontmatter and regex
exclusions, forced reindex, empty notes, rename/delete lifecycle, persistence
failures, concurrent metadata writes, and active-view race handling.

### Manual Obsidian verification

Passed on `e8da5ad` with Obsidian 1.13.1, Similar Notes 1.6.0, and the
built-in `sentence-transformers/all-MiniLM-L6-v2` model:

- [x] Loaded the branch in a disposable vault; the main vault was untouched.
- [x] Frontmatter-only and regex-excluded edits skipped re-embedding.
- [x] A body edit generated and saved a fresh embedding.
- [x] After a full app restart, the persisted hash still skipped re-embedding.
- [x] `Reindex all notes` embedded unchanged notes, confirming the force bypass.
- [x] No indexing errors occurred.

Observed logs: `Indexable text unchanged ... skipping re-embedding`,
`Generating embeddings for 1 chunks`, and, after restart,
`Loaded 2 modification times from IndexedDB`.

## Notes

`docs/indexable-text-hash-spec.md` documents hash input, persistence, migration,
and failure ordering.
